### PR TITLE
メッセージ全文表示画面の実装

### DIFF
--- a/src/island/message/user_message.tsx
+++ b/src/island/message/user_message.tsx
@@ -5,33 +5,44 @@ import styles from "../../styles/island/user_message_post.module.css";
 export default function UserMessage(){
 
     return(
-        <>
-            <div>
+            <div className={styles.back}>
                 <Link to={`/island/post`}>
                 <img src="/island/close_btn.png" 
                      alt="閉じるボタン" 
                      className={styles.close_btn}
                 />
                 </Link>
-                <p>from:</p>
-                <img src="/user/user_icon.png" alt="アイコン"/>                
-                <h3>ユーザーネーム</h3>
-                <p>受信日時:20XX年XX月XX日</p>
-                <p>テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                </p>
+                <div className={styles.receive}>
+                    <div className={styles.flex}>
+                        <p className={styles.from}>from:</p>
+                        <img src="/user/user_icon.png" 
+                            alt="アイコン"
+                        />
+                        <h3 className={styles.userName}>ユーザーネーム</h3>  
+                        <p className={styles.receiving_time}>受信日時:20XX年XX月XX日</p>            
+                    </div>
+                    <p className={styles.text_body}>
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    </p>
+                </div>
+            <div className={styles.reply}>
+                <div className={styles.flex}>
+                    <div className={styles.reply_btn}>
+                            <Link to={``}>
+                                <button>返信する</button>
+                            </Link>
+                    </div>
+                    <p className={styles.send_to}>to:</p>
+                    <h3 className={styles.reply_userName}>ユーザーネーム</h3>
+                </div>
+                <div id={styles.text_area}>
+                    <textarea name="reply"></textarea>
+                </div>
             </div>
-            <div>
-                <Link to={``}>
-                    <button>返信する</button>
-                </Link>
-                <p>to:</p>
-                <h3>ユーザーネーム</h3>
-                <textarea name="reply" id=""></textarea>
-            </div>
-        </>
+        </div>
     )
 }

--- a/src/styles/user/island_message_post.module.css
+++ b/src/styles/user/island_message_post.module.css
@@ -34,7 +34,7 @@
     margin: 0 0 0 40px;
 }
 
-.userName {
+.islandName {
     margin: 0 0 0 50px;
     padding-top: 35px;
     font-size: 20px;

--- a/src/styles/user/operation_message_post.module.css
+++ b/src/styles/user/operation_message_post.module.css
@@ -22,6 +22,7 @@
     display: flex;
 }
 
+
 .from {
     font-size: 30px;
     margin-left: 150px;
@@ -34,7 +35,7 @@
     margin: 0 0 0 40px;
 }
 
-.userName {
+.operation {
     margin: 0 0 0 50px;
     padding-top: 35px;
     font-size: 20px;
@@ -49,37 +50,4 @@
     text-align: center;
 }
 
-.reply {
-    /* border: 2px solid black; */
-    background-color: white;
-    width: 80%;
-    margin-left: auto;
-    margin-right: auto;
-}
 
-.reply_btn {
-    margin-left: 100px;
-    padding-top: 40px;
-}
-
-.send_to {
-    font-size: 30px;
-    margin-left: 60px;
-}
-
-.reply_userName {
-    margin: 0 0 0 40px;
-    padding-top: 36px;
-    font-size: 20px;
-
-}
-
-textarea {
-    width: 800px;
-    height: 400px;
-}
-
-#text_area {
-    text-align: center;
-    padding-bottom: 50px;
-}

--- a/src/styles/user/scout_message_post.module.css
+++ b/src/styles/user/scout_message_post.module.css
@@ -11,7 +11,7 @@
 
 .receive {
     background-color: white;
-    padding-bottom: 20px;
+    padding-bottom: 50px;
     margin-bottom: 20px;
     width: 80%;
     margin-left: auto;
@@ -34,7 +34,7 @@
     margin: 0 0 0 40px;
 }
 
-.userName {
+.islandName {
     margin: 0 0 0 50px;
     padding-top: 35px;
     font-size: 20px;
@@ -45,41 +45,10 @@
     margin: 0 0 0 300px;
 }
 
-.text_body {
+.scoutMessage {
     text-align: center;
 }
 
-.reply {
-    /* border: 2px solid black; */
-    background-color: white;
-    width: 80%;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.reply_btn {
-    margin-left: 100px;
-    padding-top: 40px;
-}
-
-.send_to {
-    font-size: 30px;
-    margin-left: 60px;
-}
-
-.reply_userName {
-    margin: 0 0 0 40px;
-    padding-top: 36px;
-    font-size: 20px;
-
-}
-
-textarea {
-    width: 800px;
-    height: 400px;
-}
-
-#text_area {
-    text-align: center;
-    padding-bottom: 50px;
+.island_detail {
+    padding-top: 30px;
 }

--- a/src/user/message/island_message.tsx
+++ b/src/user/message/island_message.tsx
@@ -1,33 +1,48 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import styles from "../../styles/user/island_message_post.module.css";
 
 export default function IslandMessage(){
 
     return(
-        <>
-            <div>
+        <div className={styles.back}>
                 <Link to={`/user/post`}>
-                <img src="/island/close_btn.png" alt="閉じるボタン" />
+                <img src="/island/close_btn.png" 
+                     alt="閉じるボタン"
+                     className={styles.close_btn} 
+                />
                 </Link>
-                <p>from:</p>
-                <img src="/island/island_icon.png" alt="島アイコン" />
-                <h3>〇〇島</h3>
-                <p>受信日時:20XX年XX月XX日</p>
-                <p>テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                </p>
+                <div className={styles.receive}>
+                    <div className={styles.flex}>
+                            <p className={styles.from}>from:</p>
+                            <img src="/island/island_icon.png" 
+                                alt="島アイコン" 
+                            />
+                            <h3 className={styles.islandName}>〇〇島</h3>
+                            <p className={styles.receiving_time}>受信日時:20XX年XX月XX日</p>
+                    </div>
+                    <p className={styles.text_body}>
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    </p>
+                </div>
+            <div className={styles.reply}>
+                <div className={styles.flex}>
+                    <div className={styles.reply_btn}>
+                        <Link to={``}>
+                            <button>返信する</button>
+                        </Link>
+                    </div>
+                    <p className={styles.send_to}>to:</p>
+                    <h3 className={styles.reply_userName}>ユーザーネーム</h3>
+                </div>
+                <div id={styles.text_area}>
+                    <textarea name="reply"></textarea>
+                </div>
             </div>
-            <div>
-                <Link to={``}>
-                    <button>返信する</button>
-                </Link>
-                <p>to:</p>
-                <h3>ユーザーネーム</h3>
-                <textarea name="reply" id=""></textarea>
-            </div>
-        </>
+        </div>
     )
 }

--- a/src/user/message/operation_message.tsx
+++ b/src/user/message/operation_message.tsx
@@ -1,25 +1,34 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import styles from "../../styles/user/operation_message_post.module.css";
 
 export default function OperationMessage(){
 
     return(
-        <>
-            <div>
+        <div className={styles.back}>
                 <Link to={`/user/post`}>
-                <img src="/island/close_btn.png" alt="閉じるボタン" />
+                <img src="/island/close_btn.png" 
+                     alt="閉じるボタン" 
+                     className={styles.close_btn}
+                />
                 </Link>
-                <p>from:</p>
-                <img src="/operation_icon.png" alt="お知らせアイコン" />
-                <h3>お知らせ</h3>
-                <p>受信日時:20XX年XX月XX日</p>
-                <p>テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
-                </p>
-            </div>
-        </>
+                <div className={styles.receive}>
+                    <div className={styles.flex}>
+                        <p className={styles.from}>from:</p>
+                        <img src="/operation_icon.png" 
+                             alt="お知らせアイコン" 
+                        />
+                        <h3 className={styles.operation}>お知らせ</h3>
+                        <p className={styles.receiving_time}>受信日時:20XX年XX月XX日</p>
+                    </div>
+                    <p className={styles.text_body}>
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+                    </p>
+                </div>
+        </div>
     )
 }

--- a/src/user/message/scout_message.tsx
+++ b/src/user/message/scout_message.tsx
@@ -1,24 +1,36 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import styles from "../../styles/user/scout_message_post.module.css";
 
 export default function ScoutMessage(){
 
     return(
-        <>
-            <div>               
+        <div className={styles.back}>              
                 <Link to={`/user/post`}>
-                <img src="/island/close_btn.png" alt="閉じるボタン" />
+                <img src="/island/close_btn.png" 
+                     alt="閉じるボタン" 
+                     className={styles.close_btn}
+                />
                 </Link>
-                <p>from:</p>
-                <img src="/island/island_icon.png" alt="島アイコン" />
-                <h3>〇〇島</h3>
-                <p>受信日時:20XX年XX月XX日</p>
-                <p>〇〇島からスカウトが届きました！</p>
-                <button>参加する</button>
-                <button>拒否する</button><br />
-                <Link to={``}>〇〇島を見に行く</Link>
-                {/* <p>回答しました</p> */}
-            </div>
-        </>
+                <div className={styles.receive}>
+                    <div className={styles.flex}>
+                        <p className={styles.from}>from:</p>
+                        <img src="/island/island_icon.png" 
+                             alt="島アイコン" 
+                        />
+                        <h3 className={styles.islandName}>〇〇島</h3>
+                        <p className={styles.receiving_time}>受信日時:20XX年XX月XX日</p>
+                    </div>
+                    <div className={styles.scoutMessage}>
+                        <p>〇〇島からスカウトが届きました！</p>
+                        <button>参加する</button>
+                        <button>拒否する</button><br />
+                        <div className={styles.island_detail}>
+                            <Link to={``}>〇〇島を見に行く</Link>
+                        </div>
+                        {/* <p>回答しました</p> */}
+                    </div>
+                </div>
+        </div>
     )
 }


### PR DESCRIPTION
## 変更箇所のURL
* ユーザーからサークルへのメッセージ画面
<img width="1440" alt="ユーザーからサークルへのメッセージ 2023-05-22 15 17 03" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/dc992c73-cd08-42f3-acd0-2d7037e49719">

* サークルからユーザーへのメッセージ画面
<img width="1440" alt="サークルからユーザーへのメッセージ 2023-05-22 15 17 34" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/bb0c58ce-96b6-4f97-b1e9-f29b5b0e1d4c">

* サークルからユーザーへのスカウトメッセージ画面
<img width="1440" alt="サークルからユーザーへのスカウトメッセージ 2023-05-22 15 18 36" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/3db06c1b-3817-411e-8943-ff752ecf8c42">

* 運営からユーザーへのお知らせ画面
<img width="1440" alt="運営からユーザーへのお知らせ 2023-05-22 15 32 30" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/5b690371-022c-4c0a-bd1e-04206a03aa9b">

## やったこと

* サークル、個人用ポストに届いたメッセージの全文表示画面の実装

## やらないこと

* なし

## できるようになること（ユーザ目線）

* ポストに届いたメッセージをクリックすると全文表示画面に遷移し、閲覧することができる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
