### PR TITLE
サークル詳細画面実装

### DIFF
--- a/src/island/[id].tsx
+++ b/src/island/[id].tsx
@@ -1,11 +1,28 @@
 import React from "react";
 import Menubar from "../components/menubarIsland";
 import MenubarIsland from "../components/menubarIsland";
+import styles from "../styles/island/islandDetail.module.css";
 
 export default function IslandDetail() {
   return (
-    <>
-      <MenubarIsland thumbnail="/login/loginCounter.png" />
-    </>
+      <div className={styles.flex}>
+        <MenubarIsland thumbnail="/login/loginCounter.png" />
+        <div className={styles.island_detail}>
+          <img src="/island/island_icon.png" alt="サークルアイコン" />
+            <h2>〇〇島</h2>
+            <p>
+              テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+              テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+              テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+              テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト<br />
+            </p>
+
+            <div className={styles.btn}>
+              <button>住民申請</button>
+              <button>メッセージを送る</button>
+            </div>
+            <button id={styles.edit_btn}>編集・削除</button>
+        </div>
+      </div>    
   );
 }

--- a/src/styles/island/islandDetail.module.css
+++ b/src/styles/island/islandDetail.module.css
@@ -1,0 +1,30 @@
+.flex {
+    display: flex;
+}
+
+.island_detail {
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+    padding-top: 80px;
+}
+
+.island_detail h2 {
+    padding-top: 20px;
+}
+
+.island_detail p {
+    padding-top: 40px;
+}
+
+.btn {
+    margin-top: 80px;
+    justify-content:space-around;
+    display: flex;
+}
+
+#edit_btn {
+    margin-top: 100px;
+    margin-left: 800px;
+    color: red;
+}


### PR DESCRIPTION
## 変更箇所のURL

*サークル詳細画面の実装
<img width="1440" alt="スクリーンショット 2023-05-23 16 45 12" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/fbd8e31c-12aa-4ed2-acfb-2d5b2d4b600a">


## やったこと

* サークル詳細画面の実装

## やらないこと

* なし

## できるようになること（ユーザ目線）

* サークルの詳細を確認できる
* 住民申請や、メッセージを送ることが可能
* オーナーの場合のUIとして、「編集・削除」ボタンがあり、この画面から編集・削除画面に遷移することが可能

## できなくなること（ユーザ目線）

* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
