### PR TITLE
掲示板表示、チャット画面遷移

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,7 @@ function App() {
           <Route path="/event/post" element={<EventPost />} />
           <Route path="/event/menbers" element={<EventMenbers />} />
           {/* chat */}
-          <Route path="/chat" element={<Chat />} />
+          <Route path="/chat/:id" element={<Chat />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import { firestore } from "../firebase";
 import styles from "../styles/Chat.module.css";
 import { chat } from "../types/chat";
 import SendMessages from "./SendMessages";
 
 const Chat = () => {
+  const { id } = useParams();
   // session?に保存されてるユーザーネーム
   // threadIDはpropsから渡される予定
   const userName = "シャチ";
-  const threadID = 1;
+  const threadID = Number(id);
   const threadTitle = "サンプル";
 
   const [messages, setMessages] = useState<chat[]>([]);
@@ -44,6 +46,7 @@ const Chat = () => {
         setMessages(snapShots as chat[]);
       });
   }, []);
+  console.log(messages);
 
   return (
     <main className={styles.content}>
@@ -89,7 +92,7 @@ const Chat = () => {
           </p>
         </div>
       ))}
-      <SendMessages />
+      <SendMessages threadID={threadID} />
     </main>
   );
 };

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -7,10 +7,10 @@ import SendMessages from "./SendMessages";
 
 const Chat = () => {
   const { id } = useParams();
-  // session?に保存されてるユーザーネーム
-  // threadIDはpropsから渡される予定
-  const userName = "シャチ";
   const threadID = Number(id);
+  // session?に保存されてるユーザーネーム
+  const userName = "シャチ";
+
   const threadTitle = "サンプル";
 
   const [messages, setMessages] = useState<chat[]>([]);
@@ -46,7 +46,7 @@ const Chat = () => {
         setMessages(snapShots as chat[]);
       });
   }, []);
-  console.log(messages);
+
 
   return (
     <main className={styles.content}>

--- a/src/components/SendMessages.tsx
+++ b/src/components/SendMessages.tsx
@@ -1,17 +1,14 @@
-import React, {  useState } from "react";
+import React, { useState } from "react";
 import { firestore } from "../firebase";
 import firebase from "firebase/compat/app";
 import styles from "../styles/Chat.module.css";
 
-const SendMessages = () => {
+const SendMessages = ({ threadID }: { threadID: number }) => {
   const [text, setText] = useState("");
 
   // ログインしているユーザーの情報を変数に格納する
   const userName = "シャチ";
   const icon = "/images/icon.png";
-
-  // propsで渡す
-  const threadID = 1;
 
   // 送信ボタンをクリックしたとき
   function handleClick(e: { preventDefault: () => void }) {
@@ -29,27 +26,27 @@ const SendMessages = () => {
   return (
     <div>
       <div>
-          <div className={styles.sendMsg}>
-            <input
-              type="text"
-              placeholder="メッセージを入力してください"
-              maxLength={500}
-              className={styles.inputText}
-              onChange={(e: { target: { value: string } }) => {
-                setText(e.target.value);
-              }}
-              value={text}
-            />
-            <div className={styles.btnWrapper}>
-              <button
-                onClick={handleClick}
-                className={styles.btn}
-                disabled={text === "" && true}
-              >
-                送信
-              </button>
-            </div>
+        <div className={styles.sendMsg}>
+          <input
+            type="text"
+            placeholder="メッセージを入力してください"
+            maxLength={500}
+            className={styles.inputText}
+            onChange={(e: { target: { value: string } }) => {
+              setText(e.target.value);
+            }}
+            value={text}
+          />
+          <div className={styles.btnWrapper}>
+            <button
+              onClick={handleClick}
+              className={styles.btn}
+              disabled={text === "" && true}
+            >
+              送信
+            </button>
           </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Thread.tsx
+++ b/src/components/Thread.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { thread } from "../types/thread";
+import { useNavigate } from "react-router-dom";
+import styles from "../styles/thread.module.css";
+
+function Thread({ thread }: { thread: thread[] }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className={styles.content}>
+      {thread.map((thread) => (
+        <div
+          key={thread.id}
+          onClick={() => {
+            navigate(`/chat/${thread.id}`);
+          }}
+          className={styles.thread}
+        >
+          <p className={styles.title}>{thread.threadTitle}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default Thread;

--- a/src/components/hooks/FetchEventThreads.tsx
+++ b/src/components/hooks/FetchEventThreads.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from "react";
+import { supabase } from "../../createClient";
+import { thread } from "../../types/thread";
+
+function FetchEventThreads(id: number, eqName: string) {
+  const [threads, setThreads] = useState<thread[]>([]);
+  useEffect(() => {
+    const fetchThread = async () => {
+      let { data: threads, error } = await supabase
+        .from("threads")
+        .select(`id, threadTitle,  events(*)`)
+        .eq(eqName, id);
+      setThreads(threads as thread[]);
+    };
+    fetchThread();
+  }, []);
+  return threads;
+}
+
+export default FetchEventThreads;

--- a/src/components/hooks/FetchIslandThreads.tsx
+++ b/src/components/hooks/FetchIslandThreads.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from "react";
+import { supabase } from "../../createClient";
+import { thread } from "../../types/thread";
+
+function FetchIslandThreads(id: number, eqName: string) {
+  const [threads, setThreads] = useState<thread[]>([]);
+  useEffect(() => {
+    const fetchThread = async () => {
+      let { data: threads, error } = await supabase
+        .from("threads")
+        .select(`id, threadTitle,  islands(thumbnail)`)
+        .eq(eqName, id);
+      setThreads(threads as thread[]);
+    };
+    fetchThread();
+  }, []);
+  return threads;
+}
+
+export default FetchIslandThreads;

--- a/src/event/thread.tsx
+++ b/src/event/thread.tsx
@@ -1,5 +1,15 @@
-import React from "react";
+import Thread from "../components/Thread";
+import FetchEventThreads from "../components/hooks/FetchEventThreads";
 
 export default function EventThread() {
-  return <></>;
+  // イベントID仮置き
+  const eventID = 2;
+  // スレッドデータの取得
+  const thread = FetchEventThreads(eventID, "eventID");
+
+  return (
+    <>
+      <Thread thread={thread} />
+    </>
+  );
 }

--- a/src/island/thread.tsx
+++ b/src/island/thread.tsx
@@ -1,8 +1,14 @@
 import React, { useState } from "react";
 import CreateThread from "../components/modalWindows/createThread";
+import FetchIslandThreads from "../components/hooks/FetchIslandThreads";
+import Thread from "../components/Thread";
 
 export default function IslandThread() {
   const [isOpen, setIsOpen] = useState(false);
+  // 仮置き
+  const islandID = 1;
+  // スレッドデータの取得
+  const thread = FetchIslandThreads(islandID, "islandID");
 
   // スレッド作成の小窓画面（モーダルウィンドウ）の開閉
   // isOpenの値がtrueの時だけ小窓画面をレンダリング（表示）する
@@ -18,6 +24,7 @@ export default function IslandThread() {
     <>
       <button onClick={openModal}>スレッドを作成する</button>
       {isOpen && <CreateThread closeModal={closeModal} />}
+      <Thread thread={thread} />
     </>
   );
 }

--- a/src/styles/thread.module.css
+++ b/src/styles/thread.module.css
@@ -1,0 +1,20 @@
+.content {
+  max-width: 70%;
+  margin: 0 auto;
+  padding: 15px 0
+}
+
+.thread {
+  padding: 10px;
+  width: 100%;
+  height: 70px;
+  border: 1px solid #333;
+  text-align: center;
+  cursor: pointer;
+  margin-bottom: 15px;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: bold;
+}

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -1,0 +1,19 @@
+type thread = {
+  id: number;
+  threadTitle: string;
+  events?: {
+    id: number;
+    eventName: string;
+    detail: string;
+    thumbnail: string;
+    startDate: string;
+    endDate: string;
+    ownerID: number;
+    createdAt: string;
+    createdBy: string;
+    updatedAt: string | null;
+    updatedBy: string | null;
+  };
+};
+
+export type { thread };


### PR DESCRIPTION
## 変更箇所のURL
- https://github.com/Hayaka3a/company-circle-sns/issues/17#issue-1711385661
## やったこと
- 掲示板の表示
- 掲示板からチャット画面の遷移
- hooksフォルダの作成
## やらないこと
- CSS

## できるようになること（ユーザ目線）
- 掲示板の一覧

## できなくなること（ユーザ目線）
なし

## 動作確認
<img width="999" alt="スクリーンショット 2023-05-23 17 08 05" src="https://github.com/Hayaka3a/company-circle-sns/assets/106084382/9ce74e05-81f4-4ba3-ab87-2f280de2ff4a">


## その他
- 島orイベントのIDは今は直書き
- グループ名をどうChatコンポーネントに渡すかは考え中
