### PR TITLE
住民申請を押した際の小窓（モーダルウィンドウ）画面の実装

### DIFF
--- a/src/components/modalWindows/createResidentApplication.tsx
+++ b/src/components/modalWindows/createResidentApplication.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import styles from "../../styles/createSendingMessage.module.css";
+
+export default function CreateResidentApplication({
+    closeResidentModal,
+}: {
+    closeResidentModal: () => void;
+}) {
+    const addHandler = () => {};
+    return(
+        <>
+            <div className={styles.overlay}>
+                <div className={styles.modal}>
+                    <div className={styles.allContents}>
+                        <img
+                        src="/modalWindow/close.png"
+                        alt="×ボタン"
+                        onClick={closeResidentModal}
+                        className={styles.close}
+                        />
+                        <div className={styles.main}>
+                        <div className={styles.title}>
+                            <h3 className={styles.h3}>○○島</h3>
+                            <p className={styles.messageName}>住民申請</p>
+                        </div>
+                        <div className={styles.input}>
+                            <label htmlFor="threadName">コメント</label><br />
+                            <textarea name="text" className={styles.textSending}></textarea>
+                        </div>
+                        </div>
+                        <div className={styles.btn}>
+                        <button onClick={addHandler}>送信する</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </>
+    );
+}

--- a/src/island/[id].tsx
+++ b/src/island/[id].tsx
@@ -3,13 +3,24 @@ import Menubar from "../components/menubarIsland";
 import MenubarIsland from "../components/menubarIsland";
 import styles from "../styles/island/islandDetail.module.css";
 import CreateSendingMessage from "../components/modalWindows/createSendingMessage";
+import CreateResidentApplication from "../components/modalWindows/createResidentApplication";
 
 export default function IslandDetail() {
-    const [isOpen, setIsOpen] = useState(false);
+    const [ isOpen, setIsOpen ] = useState(false);
+    const [ isResidentOpen, setIsResidentOpen ] = useState(false);
+
+    // 住民申請を押した際の小窓画面（モーダルウィンドウ）の開閉
+    // isResidentOpenの値がtrueの時だけ小窓画面をレンダリング（表示）する
+    const openResindentModal = () => {
+      setIsResidentOpen(true);
+    };
+
+    const closeResidentModal = () => {
+      setIsResidentOpen(false);
+    };
 
     // メッセージを送るを押した際の小窓画面（モーダルウィンドウ）の開閉
     // isOpenの値がtrueの時だけ小窓画面をレンダリング（表示）する
-
     const openModal = () => {
       setIsOpen(true);
     };
@@ -32,7 +43,8 @@ export default function IslandDetail() {
             </p>
 
             <div className={styles.btn}>
-              <button>住民申請</button>
+              <button onClick={openResindentModal}>住民申請</button>
+              {isResidentOpen && <CreateResidentApplication closeResidentModal={closeResidentModal} />}
               <button onClick={openModal}>メッセージを送る</button>
               {isOpen && <CreateSendingMessage closeModal={closeModal} />}
             </div>


### PR DESCRIPTION
## 変更箇所のURL

* 住民申請を押下した際に表示されるモーダルウィンドウ
<img width="1440" alt="スクリーンショット 2023-05-24 16 18 48" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/0fa534ab-9b6d-445e-abfa-a987b1aef67f">


## やったこと

* 住民申請を押下した際のモーダルウィンドウの画面実装

## やらないこと

* 送信機能の実装（今後行います）

## できるようになること（ユーザ目線）

* 住民申請のメッセージの記述可能
* 「住民申請」ボタン、×（閉じるボタン）を押下した際にウィンドウ開閉が可能

## できなくなること（ユーザ目線）

* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
