### PR TITLE
Feature/thread

### DIFF
--- a/src/components/modalWindows/createThread.tsx
+++ b/src/components/modalWindows/createThread.tsx
@@ -36,7 +36,6 @@ export default function CreateThread({
           .single();
         if (data) {
           setEventName(data.eventName);
-          console.log(data);
         }
       }
     };

--- a/src/components/modalWindows/createThread.tsx
+++ b/src/components/modalWindows/createThread.tsx
@@ -57,6 +57,7 @@ export default function CreateThread({
     } else {
       console.log("スレッド作成成功");
       closeModal();
+      window.location.reload();
     }
   };
 

--- a/src/components/modalWindows/createThread.tsx
+++ b/src/components/modalWindows/createThread.tsx
@@ -1,12 +1,48 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "../../styles/createThread.module.css";
+import { supabase } from "../../createClient";
 
 export default function CreateThread({
   closeModal,
+  islandID,
 }: {
   closeModal: () => void;
+  islandID: number;
 }) {
-  const addHandler = () => {};
+  const [threadTitle, setThreadTitle] = useState("");
+  const [islandName, setIslandName] = useState("");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data } = await supabase
+        .from("islands")
+        .select("islandName")
+        .eq("id", islandID)
+        .single();
+      if (data) {
+        setIslandName(data.islandName);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  // スレッド作成送信
+  // insert()メソッドはPromiseを返す非同期関数だからasync/awaitが必要
+  const addHandler = async (e: { preventDefault: () => void }) => {
+    e.preventDefault();
+
+    const { data, error } = await supabase
+      .from("threads")
+      .insert({ threadTitle, islandID, status: true });
+    if (error) {
+      console.error("Failed to create thread:", error.message);
+    } else {
+      console.log("スレッド作成成功");
+      closeModal();
+    }
+  };
+
   return (
     <>
       <div className={styles.overlay}>
@@ -20,12 +56,17 @@ export default function CreateThread({
             />
             <div className={styles.main}>
               <div className={styles.title}>
-                <h3 className={styles.h3}>○○島</h3>
+                <h3 className={styles.h3}>{islandName}島</h3>
                 <p className={styles.p}>新規スレッド作成</p>
               </div>
               <div className={styles.input}>
                 <label htmlFor="threadName">スレッド名</label>
-                <input type="text"></input>
+                <input
+                  type="text"
+                  onChange={(e) => {
+                    setThreadTitle(e.target.value);
+                  }}
+                ></input>
               </div>
             </div>
             <div>

--- a/src/components/modalWindows/createThread.tsx
+++ b/src/components/modalWindows/createThread.tsx
@@ -5,27 +5,44 @@ import { supabase } from "../../createClient";
 export default function CreateThread({
   closeModal,
   islandID,
+  eventID,
 }: {
   closeModal: () => void;
-  islandID: number;
+  islandID: number | null;
+  eventID: number | null;
 }) {
   const [threadTitle, setThreadTitle] = useState("");
   const [islandName, setIslandName] = useState("");
+  const [eventName, setEventName] = useState("");
 
   useEffect(() => {
     const fetchData = async () => {
-      const { data } = await supabase
-        .from("islands")
-        .select("islandName")
-        .eq("id", islandID)
-        .single();
-      if (data) {
-        setIslandName(data.islandName);
+      // サークル（島）のスレッド作成の場合
+      if (islandID) {
+        const { data } = await supabase
+          .from("islands")
+          .select("islandName")
+          .eq("id", islandID)
+          .single();
+        if (data) {
+          setIslandName(data.islandName);
+        }
+        // イベントのスレッド作成の場合
+      } else if (eventID) {
+        const { data } = await supabase
+          .from("events")
+          .select("eventName")
+          .eq("id", eventID)
+          .single();
+        if (data) {
+          setEventName(data.eventName);
+          console.log(data);
+        }
       }
     };
 
     fetchData();
-  }, []);
+  }, [islandID, eventID]);
 
   // スレッド作成送信
   // insert()メソッドはPromiseを返す非同期関数だからasync/awaitが必要
@@ -34,7 +51,7 @@ export default function CreateThread({
 
     const { data, error } = await supabase
       .from("threads")
-      .insert({ threadTitle, islandID, status: true });
+      .insert({ threadTitle, islandID, eventID, status: true });
     if (error) {
       console.error("Failed to create thread:", error.message);
     } else {
@@ -56,7 +73,10 @@ export default function CreateThread({
             />
             <div className={styles.main}>
               <div className={styles.title}>
-                <h3 className={styles.h3}>{islandName}島</h3>
+                {/* サークル（島）のスレッド作成の場合 */}
+                {islandID && <h3 className={styles.h3}>{islandName}島</h3>}
+                {/* イベントのスレッド作詞の場合 */}
+                {eventID && <h3 className={styles.h3}>{eventName}</h3>}
                 <p className={styles.p}>新規スレッド作成</p>
               </div>
               <div className={styles.input}>

--- a/src/event/thread.tsx
+++ b/src/event/thread.tsx
@@ -2,18 +2,40 @@ import Thread from "../components/Thread";
 import FetchEventThreads from "../components/hooks/FetchEventThreads";
 import styles from "../styles/thread.module.css";
 import MenubarEvent from "../components/menubarEvent";
+import CreateThread from "../components/modalWindows/createThread";
+import { useState } from "react";
 
 export default function EventThread() {
+  const [isOpen, setIsOpen] = useState(false);
+
   // イベントID仮置き
   const eventID = 2;
   // スレッドデータの取得
   const thread = FetchEventThreads(eventID, "eventID");
+
+  // スレッド作成の小窓画面（モーダルウィンドウ）の開閉
+  // isOpenの値がtrueの時だけ小窓画面をレンダリング（表示）する
+  const openModal = () => {
+    setIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
 
   return (
     <>
       <div className={styles.flex}>
         <MenubarEvent thumbnail={""} />
         <div className={styles.threadWrapper}>
+          <button onClick={openModal}>スレッドを作成する</button>
+          {isOpen && (
+            <CreateThread
+              closeModal={closeModal}
+              islandID={null}
+              eventID={eventID}
+            />
+          )}
           <Thread thread={thread} />
         </div>
       </div>

--- a/src/island/thread.tsx
+++ b/src/island/thread.tsx
@@ -29,7 +29,11 @@ export default function IslandThread() {
         <div className={styles.threadWrapper}>
           <button onClick={openModal}>スレッドを作成する</button>
           {isOpen && (
-            <CreateThread closeModal={closeModal} islandID={islandID} />
+            <CreateThread
+              closeModal={closeModal}
+              islandID={islandID}
+              eventID={null}
+            />
           )}
           <Thread thread={thread} />
         </div>

--- a/src/island/thread.tsx
+++ b/src/island/thread.tsx
@@ -28,7 +28,9 @@ export default function IslandThread() {
         <MenubarIsland thumbnail={null} />
         <div className={styles.threadWrapper}>
           <button onClick={openModal}>スレッドを作成する</button>
-          {isOpen && <CreateThread closeModal={closeModal} />}
+          {isOpen && (
+            <CreateThread closeModal={closeModal} islandID={islandID} />
+          )}
           <Thread thread={thread} />
         </div>
       </div>


### PR DESCRIPTION
## 変更箇所のURL

- src/components/modalWindows/createThread.tsx
- src/island/thread.tsx
- src/event/thread.tsx

## やったこと

- スレッド作成機能実装
thread.tsx画面からislandIDもしくはeventIDをコンポーネントに渡し、スレッドの小窓画面に島名もしくはイベント名を表示。
テキストボックスに入力されたスレッド名と一緒にislandIDとeventID（どちらかはnullの状態で）とstatus情報をthreadsテーブルに送信し、小窓画面を閉じる。


- createTheradコンポーネントをsrc/event/thread.tsxにも配置

## やらないこと

CSS

## できるようになること（ユーザ目線）

島のスレッド作成

## できなくなること（ユーザ目線）

無

## 動作確認

### イベント名orサークル（島）名表示
- イベント
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/84fc2ec6-3a22-4e17-b109-5999cb32ddd4)

- サークル（島）
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/1106936d-7377-4eae-9eb4-6370d6418416)

### 以下成功時
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/298a3af6-807f-4915-b73a-5308cc03452a)




## その他

