### PR TITLE
createSendingMessage.module.css内変更、削除ボタンを押下した際のモーダルウィンドウ実装

### DIFF
--- a/src/components/modalWindows/createDeletePage.tsx
+++ b/src/components/modalWindows/createDeletePage.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import styles from "../../styles/createDeletePage.module.css";
+
+export default function CreateDeletePage({
+  closeDeleteModal,
+}: {
+  closeDeleteModal: () => void;
+}) {
+  const deleteHandler = () => {};
+  return (
+    <>
+      <div className={styles.overlay}>
+        <div className={styles.modal}>
+          <div className={styles.allContents}>
+            <img
+              src="/modalWindow/close.png"
+              alt="×ボタン"
+              onClick={closeDeleteModal}
+              className={styles.close}
+            />
+            <div className={styles.main}>
+              <div className={styles.title}>
+                <h3 className={styles.h3}>島を沈没させてもよろしいですか？</h3>
+              </div>
+              <div className={styles.flexIcon}>
+                <img src= "/island/island_icon.png" 
+                     alt="サークルアイコン" 
+                />
+                <p>〇〇島</p>
+              </div>
+            </div>
+            <div>
+              <button onClick={deleteHandler}>島を沈没（削除）させる</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/island/[id].tsx
+++ b/src/island/[id].tsx
@@ -4,6 +4,7 @@ import MenubarIsland from "../components/menubarIsland";
 import styles from "../styles/island/islandDetail.module.css";
 import CreateSendingMessage from "../components/modalWindows/createSendingMessage";
 import CreateResidentApplication from "../components/modalWindows/createResidentApplication";
+import { Link } from "react-router-dom";
 
 export default function IslandDetail() {
     const [ isOpen, setIsOpen ] = useState(false);
@@ -48,7 +49,9 @@ export default function IslandDetail() {
               <button onClick={openModal}>メッセージを送る</button>
               {isOpen && <CreateSendingMessage closeModal={closeModal} />}
             </div>
-            <button id={styles.edit_btn}>編集・削除</button>
+            <Link to= {`/island/edit`}>
+              <button id={styles.edit_btn}>編集・削除</button>
+            </Link>
         </div>
       </div>    
   );

--- a/src/island/edit.tsx
+++ b/src/island/edit.tsx
@@ -1,10 +1,22 @@
 import React, { useState, useEffect, ChangeEvent } from "react";
 import styles from "../styles/islandEdit.module.css";
 import ComboBox from "../components/comboBox";
+import CreateDeletePage from "../components/modalWindows/createDeletePage";
 
 
 export default function IslandEdit(){
     const [imageUrl, setImageUrl] = useState("/login/loginCounter.png");
+    const [ isDeleteOpen, setIsDeleteOpen ] = useState(false);
+
+    // 削除を押した際の小窓画面（モーダルウィンドウ）の開閉
+    // isDeleteOpenの値がtrueの時だけ小窓画面をレンダリング（表示）する
+    const openDeleteModal = () => {
+        setIsDeleteOpen(true);
+    };
+
+    const closeDeleteModal = () => {
+        setIsDeleteOpen(false);
+    };
 
     // データベースのデータを取ってくる
     const tagOptions = ["サッカー", "大人数", "野外", "野球"];
@@ -66,7 +78,8 @@ export default function IslandEdit(){
                     <button onClick={addHandler} className={styles.plus_btn}>追加</button>
                 </div>
                 <button className={styles.edit_btn}>編集</button>
-                <button id={styles.delete_btn}>削除</button>
+                <button onClick={openDeleteModal} id={styles.delete_btn}>削除</button>
+                {isDeleteOpen && <CreateDeletePage closeDeleteModal={closeDeleteModal} />}
             </div>
        </div>
     )

--- a/src/styles/createDeletePage.module.css
+++ b/src/styles/createDeletePage.module.css
@@ -1,6 +1,6 @@
 .overlay {
     z-index: 1; /* 重ねた時の順番 */
-
+  
     /* 画面全体を覆う */
     position: fixed;
     top: 0;
@@ -8,82 +8,73 @@
     width: 100%;
     height: 100%;
     background-color: rgba(0, 0, 0, 0.5);
-
+  
     /* 画面の中央に要素を表示 */
     display: flex;
     align-items: center;
     justify-content: center;
-}
+  }
   
-.modal {
+  .modal {
     z-index: 2;
-    width: 70%;
+    width: 50%;
     padding: 1em;
     background: #fff;
     text-align: center;
     justify-content: center; /* 水平方向の中央揃え */
     align-items: center; /* 垂直方向の中央揃え */
     flex-direction: column; /* 縦方向に並べる */
-    height: 70%;
+    height: 50%;
     position: relative;
-}
+  }
   
-.close {
+  .close {
     position: absolute;
     top: 10px;
     right: 10px;
-}
+  }
   
-.allContents {
+  .allContents {
     height: 50vh;
     justify-content: center; /* 水平方向 */
     align-items: center; /* 垂直方向 */
     flex-direction: column; /* 縦方向 */
     display: flex;
-}
+  }
   
-.input {
+  .input {
     align-items: flex-start; /* 垂直方向 */
     justify-content: center; /* 水平方向 */
-    display: block;
-    margin-top: 50px;
-}
-
-.input label {
-    padding: 0 350px 0 0;
-}
+    display: flex;
+  }
   
-.main {
+  .main {
     width: auto;
     font-size: 1.5em;
     height: 40vh;
     width: 70%;
     display: grid;
     grid-template-rows: repeat(auto-fit, minmax(0, 1fr));
-}
+  }
   
-.title {
+  .title {
     align-items: center; /* 垂直方向 */
     justify-content: center; /* 水平方向 */
     flex-direction: column; /* 縦方向 */
-    margin-top: 75px;
-}
-  
-.h3 {
-    margin-bottom: 0;
-}
-  
-.messageName {
-    margin-top: 0;
-    padding-top: 0;
-}
+  }
 
-.btn {
-    display: block;
-    margin: 260px 0 0 0;
-}
+  .flexIcon {
+    display: flex;
+  }
 
-.textSending {
-    width: 500px;
-    height: 270px;
-}
+  .flexIcon img {
+    width: 80px;
+    height: 80px;
+    padding-left: 60px;
+  }
+
+  .flexIcon p {
+    padding-left: 80px;
+  }
+
+  

--- a/src/styles/island/islandDetail.module.css
+++ b/src/styles/island/islandDetail.module.css
@@ -27,4 +27,5 @@
     margin-top: 100px;
     margin-left: 800px;
     color: red;
+    font-weight: bold
 }


### PR DESCRIPTION
削除画面（モーダルウィンドウ）作成

## 変更箇所のURL

* サークルの「削除」ボタンを押下した際のモーダルウィンドウ実装
<img width="1440" alt="スクリーンショット 2023-05-25 9 33 38" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/661efeaf-1324-435c-b0f1-24ffeba6b6cd">


*createSendingMessage.module.css内のlabel指定の変更

## やったこと

* サークル削除ボタンを押下した際のモーダルウィンドウ実装
* createSendingMessage.module.css内のlabelに対する指定が不適切であったため修正（ヘッダーに影響してしまう）

## やらないこと

* css
* 機能の実装
（上記、今後行います）

## できるようになること（ユーザ目線）

* サークルの削除が可能となる
* 「削除」ボタン、×（閉じる）ボタンよりウィンドウの開閉が可能

## できなくなること（ユーザ目線）

* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
