### PR TITLE
削除確認小窓の実装

### DIFF
--- a/src/components/modalWindows/createDeletingCheck.tsx
+++ b/src/components/modalWindows/createDeletingCheck.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import styles from "../../styles/createDeletingCheck.module.css";
+
+export default function CreateDeleteCheck({
+  closeDeleteCheckModal,
+}: {
+  closeDeleteCheckModal: () => void;
+}) {
+  const deleteCheckHandler = () => {};
+  return (
+    <>
+      <div className={styles.overlay}>
+        <div className={styles.modal}>
+          <div className={styles.allContents}>
+            <img
+              src="/modalWindow/close.png"
+              alt="×ボタン"
+              onClick={closeDeleteCheckModal}
+              className={styles.close}
+            />
+            <div className={styles.main}>
+              <div className={styles.title}>
+                <h3 className={styles.h3}>本当に島を沈没させてもよろしいですか？</h3>
+              </div>
+              <div className={styles.flexIcon}>
+                <img src= "/island/island_icon.png" 
+                     alt="サークルアイコン" 
+                />
+                <p>〇〇島</p>
+              </div>
+              <div>
+                <p>削除するために下記のテキストボックスに<br /> ”〇〇島”と入力してください</p>
+                <input type="text" name="テキストボックス" id={styles.deleteCheck} />
+              </div>
+            </div>
+            <div>
+              <button onClick={deleteCheckHandler} className={styles.dCheck_btn}>削除する</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/island/edit.tsx
+++ b/src/island/edit.tsx
@@ -2,11 +2,13 @@ import React, { useState, useEffect, ChangeEvent } from "react";
 import styles from "../styles/islandEdit.module.css";
 import ComboBox from "../components/comboBox";
 import CreateDeletePage from "../components/modalWindows/createDeletePage";
+import CreateDeleteCheck from "../components/modalWindows/createDeletingCheck";
 
 
 export default function IslandEdit(){
     const [imageUrl, setImageUrl] = useState("/login/loginCounter.png");
     const [ isDeleteOpen, setIsDeleteOpen ] = useState(false);
+    const [ isDeleteCheckOpen, setIsDleteCheckOpen ] = useState(false);
 
     // 削除を押した際の小窓画面（モーダルウィンドウ）の開閉
     // isDeleteOpenの値がtrueの時だけ小窓画面をレンダリング（表示）する
@@ -17,6 +19,17 @@ export default function IslandEdit(){
     const closeDeleteModal = () => {
         setIsDeleteOpen(false);
     };
+
+    // 島を沈没（削除）させるを押した際の小窓画面（モーダルウィンドウ）の開閉
+    // isDeleteCheckOpenの値がtrueの時だけ小窓画面をレンダリング（表示）する
+    const openDeleteCheckModal = () => {
+        setIsDleteCheckOpen(true);
+    };
+
+    const closeDeleteCheckModal = () => {
+        setIsDleteCheckOpen(false);
+    };
+
 
     // データベースのデータを取ってくる
     const tagOptions = ["サッカー", "大人数", "野外", "野球"];
@@ -78,8 +91,10 @@ export default function IslandEdit(){
                     <button onClick={addHandler} className={styles.plus_btn}>追加</button>
                 </div>
                 <button className={styles.edit_btn}>編集</button>
-                <button onClick={openDeleteModal} id={styles.delete_btn}>削除</button>
-                {isDeleteOpen && <CreateDeletePage closeDeleteModal={closeDeleteModal} />}
+                {/* <button onClick={openDeleteModal} id={styles.delete_btn}>削除</button> */}
+                {/* {isDeleteOpen && <CreateDeletePage closeDeleteModal={closeDeleteModal} />} */}
+                <button onClick={openDeleteCheckModal} id={styles.delete_btn}>削除</button>
+                {isDeleteCheckOpen && <CreateDeleteCheck closeDeleteCheckModal={closeDeleteCheckModal} />}
             </div>
        </div>
     )

--- a/src/styles/createDeletingCheck.module.css
+++ b/src/styles/createDeletingCheck.module.css
@@ -1,0 +1,92 @@
+.overlay {
+    z-index: 1; /* 重ねた時の順番 */
+  
+    /* 画面全体を覆う */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+  
+    /* 画面の中央に要素を表示 */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .modal {
+    z-index: 2;
+    width: 50%;
+    padding: 1em;
+    background: #fff;
+    text-align: center;
+    justify-content: center; /* 水平方向の中央揃え */
+    align-items: center; /* 垂直方向の中央揃え */
+    flex-direction: column; /* 縦方向に並べる */
+    height: 70%;
+    position: relative;
+  }
+  
+  .close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+  
+  .allContents {
+    height: 50vh;
+    justify-content: center; /* 水平方向 */
+    align-items: center; /* 垂直方向 */
+    flex-direction: column; /* 縦方向 */
+    display: flex;
+    margin: 90px 0 0 0;
+  }
+  
+  .input {
+    align-items: flex-start; /* 垂直方向 */
+    justify-content: center; /* 水平方向 */
+    display: flex;
+  }
+  
+  .main {
+    width: auto;
+    font-size: 1.5em;
+    height: 40vh;
+    width: 70%;
+    display: grid;
+    grid-template-rows: repeat(auto-fit, minmax(0, 1fr));
+  }
+  
+  .title {
+    align-items: center; /* 垂直方向 */
+    justify-content: center; /* 水平方向 */
+    flex-direction: column; /* 縦方向 */
+  }
+
+  .flexIcon {
+    display: flex;
+  }
+
+  .flexIcon img {
+    width: 80px;
+    height: 80px;
+    padding-left: 60px;
+  }
+
+  .flexIcon p {
+    padding-left: 80px;
+  }
+
+  .h3 {
+    margin-top: 0;
+    font-size: 26px;
+  }
+
+  #deleteCheck {
+    width: 400px;
+  }
+
+  .dCheck_btn {
+    margin: 100px 0 0 0;
+  }


### PR DESCRIPTION
## 変更箇所のURL

*サークル削除の確認モーダルウィンドウの実装
<img width="1440" alt="スクリーンショット 2023-05-25 10 40 00" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/b2d8f000-72f7-4235-9e2b-57ac18720b8e">


## やったこと

* サークル削除の確認小窓のコンポーネント、css実装

## やらないこと

* 機能実装、css（今後行います）

## できるようになること（ユーザ目線）

* 誤って削除ボタンを押した際に、確認小窓に画面変更されるため、すぐに削除されない（段階的に削除するフロー）
* 削除するためにサークル名入力
* ×（閉じる）ボタンを押下し、モーダルウィンドウを閉じることが可能

## できなくなること（ユーザ目線）

* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
