### PR TITLE
住民申請許可機能実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import EventEdit from "./event/edit";
 import EventThread from "./event/thread";
 import EventPost from "./event/post";
 import EventMembers from "./event/members";
+import EventEntryPermitPage from "./event/post/entryPermitPage";
 
 // islandフォルダ
 import IslandDetail from "./island/[id]";
@@ -31,7 +32,7 @@ import IslandCreate from "./island/create";
 import IslandMembers from "./island/members";
 import IslandPost from "./island/post";
 import UserMessage from "./island/message/user_message";
-import EntryPermitPage from "./island/post/entryPermitPage";
+import IslandEntryPermitPage from "./island/post/entryPermitPage";
 
 // searchフォルダ
 import Search from "./search";
@@ -78,7 +79,7 @@ function App() {
           <Route path="/island/post/:id" element={<IslandPost />} />
           <Route
             path="/island/post/entryPermit/:id"
-            element={<EntryPermitPage />}
+            element={<IslandEntryPermitPage />}
           />
           <Route
             path="/island/message/user_message"
@@ -91,6 +92,10 @@ function App() {
           <Route path="/event/thread/:id" element={<EventThread />} />
           <Route path="/event/post/:id" element={<EventPost />} />
           <Route path="/event/members/:id" element={<EventMembers />} />
+          <Route
+            path="/event/post/entryPermit/:id"
+            element={<EventEntryPermitPage />}
+          />
           {/* chat */}
           <Route path="/chat/:id" element={<Chat />} />
         </Routes>

--- a/src/components/modalWindows/deleteConfirmation.tsx
+++ b/src/components/modalWindows/deleteConfirmation.tsx
@@ -44,8 +44,6 @@ export default function DeleteComfirmation({
           .update({ status: true })
           .eq(`userID`, user)
           .eq(`${table}ID`, params);
-
-        if (!data) return;
         if (error) {
           console.error(error.message);
         } else {

--- a/src/components/post/entryPermit.tsx
+++ b/src/components/post/entryPermit.tsx
@@ -5,7 +5,7 @@ import { useParams } from "react-router-dom";
 import { Message } from "../../types/entryPermit";
 
 export default function EntryPermit({ table }: { table: string }) {
-  const [message, setMessage] = useState();
+  const [message, setMessage] = useState<Message>();
 
   const params = useParams();
   const paramsID = parseInt(params.id);
@@ -17,58 +17,51 @@ export default function EntryPermit({ table }: { table: string }) {
   async function fetchData() {
     const { data, error } = await supabase
       .from("posts")
-      .select(`*,messages(*,applications(*))`)
-      .eq(`${table}ID`, paramsID);
+      .select(`*,messages(*,applications(*),users(*))`)
+      .eq(`${table}ID`, paramsID)
+      .eq("status", false);
+    if (error) {
+      console.log(error);
+    }
 
-    // const selectApp = data[0].filter((application) => applications.id === true);
-    console.log(data, "あ");
-    setMessage(data[0].messages);
+    //applicationsが取得できたものだけで新たな配列を作成
+    const selectApp = data[0].messages.filter(
+      (message) => message.applications.length > 0,
+    );
+    setMessage(selectApp);
   }
-  console.log(message);
-  const entryDesired = [
-    {
-      id: 1,
-      famiryName: "田中",
-      firstName: "太郎",
-      icon: "a",
-      message:
-        "これは住民申請用の５０文字の文章ですテキストテキストテキストテキストテキストテキストテキストテキスト",
-    },
-    {
-      id: 2,
-      famiryName: "田無川",
-      firstName: "一",
-      icon: "a",
-      message: "aaaaa",
-    },
-  ];
 
   return (
     <div className={styles.main}>
       <h2>許可待ちの住民申請</h2>
-      {entryDesired.map((message) => {
-        return (
-          <div className={styles.box} key={message.id}>
-            <div className={styles.left}>
-              <img src={message.icon} className={styles.icon} alt="アイコン" />
-            </div>
-            <div className={styles.right}>
-              <div className={styles.first}>
-                <p className={styles.name}>
-                  {message.famiryName + message.firstName}
-                </p>
-                <div className={styles.button}>
-                  <button className={styles.OK}>許可</button>
-                  <button className={styles.NG}>却下</button>
+      {message &&
+        message.map((message) => {
+          return (
+            <div className={styles.box} key={message.id}>
+              <div className={styles.left}>
+                <img
+                  src={message.users.icon}
+                  className={styles.icon}
+                  alt="アイコン"
+                />
+              </div>
+              <div className={styles.right}>
+                <div className={styles.first}>
+                  <p className={styles.name}>
+                    {message.users.familyName + message.users.firstName}
+                  </p>
+                  <div className={styles.button}>
+                    <button className={styles.OK}>許可</button>
+                    <button className={styles.NG}>却下</button>
+                  </div>
+                </div>
+                <div className={styles.second}>
+                  <p>{message.message}</p>
                 </div>
               </div>
-              <div className={styles.second}>
-                <p>{message.message}</p>
-              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
     </div>
   );
 }

--- a/src/components/post/entryPermit.tsx
+++ b/src/components/post/entryPermit.tsx
@@ -20,6 +20,7 @@ export default function EntryPermit({ table }: { table: string }) {
       .select(`*,messages(*,applications(*),users(*))`)
       .eq(`${table}ID`, paramsID)
       .eq(`messages.isRead`, false)
+      .eq(`messages.isAnswered`, false)
       .eq("status", false);
     if (error) {
       console.log(error, "エラー");

--- a/src/components/post/entryPermit.tsx
+++ b/src/components/post/entryPermit.tsx
@@ -87,7 +87,7 @@ export default function EntryPermit({ table }: { table: string }) {
 
   return (
     <div className={styles.main}>
-      <h2>許可待ちの住民申請</h2>
+      <h2 className={styles.title}>許可待ちの住民申請</h2>
       {message && message.length > 0 ? (
         message.map((data) => {
           return (

--- a/src/event/post/entryPermitPage.tsx
+++ b/src/event/post/entryPermitPage.tsx
@@ -1,11 +1,11 @@
 import MenubarIsland from "../../components/menubarIsland";
 import EntryPermit from "../../components/post/entryPermit";
 import styles from "../../styles/entryPermit.module.css";
-export default function IslandEntryPermitPage() {
+export default function EventEntryPermitPage() {
   return (
     <div className={styles.display}>
       <MenubarIsland thumbnail="a" />
-      <EntryPermit table={"island"} />
+      <EntryPermit table={"event"} />
     </div>
   );
 }

--- a/src/styles/entryPermit.module.css
+++ b/src/styles/entryPermit.module.css
@@ -75,6 +75,6 @@
 
 .second {
   background-color: rgba(255, 245, 217, 0.5);
-  width: 90%;
+  width: 88%;
   font-size: 12.5px;
 }

--- a/src/styles/entryPermit.module.css
+++ b/src/styles/entryPermit.module.css
@@ -13,9 +13,13 @@
   margin-left: 5%;
 }
 .left {
-  width: 200px;
+  width: 140px;
 }
 .icon {
+  border-radius: 50%;
+  height: 120px;
+  border: 1px solid orange;
+  margin: auto;
 }
 
 .right {
@@ -30,22 +34,15 @@
   margin-right: 15%;
 }
 .OK {
-  float: right;
-  display: block;
-  text-align: center;
-  vertical-align: middle;
-  text-decoration: none;
-  position: relative;
-  width: 90px;
-  padding: 1rem 1rem;
-  margin-top: 3px;
+  width: 80px;
+  margin-top: 15px;
   font-weight: bold;
   border-radius: 10px;
   color: rgba(94, 70, 44, 1);
   border: 3px solid rgba(255, 182, 112, 1);
   box-shadow: 5px 5px rgba(255, 182, 112, 1);
   transition: 0.3s ease-in-out;
-  height: 50px;
+  height: 40px;
 }
 .OK:hover {
   box-shadow: none;
@@ -53,23 +50,16 @@
   color: rgba(94, 70, 44, 0.6);
 }
 .NG {
-  float: right;
-  display: block;
-  text-align: center;
-  vertical-align: middle;
-  text-decoration: none;
-  position: relative;
-  width: 90px;
+  width: 80px;
   margin-left: 20px;
-  margin-top: 3px;
-  padding: 1rem 1rem;
+  margin-top: 15px;
   font-weight: bold;
   border-radius: 10px;
   color: rgba(94, 70, 44, 1);
   border: 3px solid #27acd9;
   box-shadow: 5px 5px #27acd9;
   transition: 0.3s ease-in-out;
-  height: 50px;
+  height: 40px;
 }
 .NG:hover {
   box-shadow: none;
@@ -78,6 +68,9 @@
 }
 .name {
   width: 200px;
+  font-size: 18px;
+  margin-top: 25px;
+  font-weight: bold;
 }
 
 .second {

--- a/src/styles/entryPermit.module.css
+++ b/src/styles/entryPermit.module.css
@@ -6,6 +6,9 @@
   width: 75%;
   margin-left: 2%;
 }
+.title {
+  margin-left: 5%;
+}
 .box {
   background-color: white;
   display: flex;
@@ -75,6 +78,7 @@
 
 .second {
   background-color: rgba(255, 245, 217, 0.5);
-  width: 88%;
+  width: 637px;
   font-size: 12.5px;
+  padding-left: 10px;
 }

--- a/src/types/entryPermit.ts
+++ b/src/types/entryPermit.ts
@@ -13,4 +13,5 @@ export type Message = {
     messageID: number;
     status: boolean;
   }[];
-};
+  users: { id: number; icon: string; familyName: string; firstName: string };
+}[];

--- a/src/types/entryPermit.ts
+++ b/src/types/entryPermit.ts
@@ -1,7 +1,7 @@
 export type Message = {
   id: number;
   message: string;
-  postedBy: string;
+  postedBy: number;
   postID: string;
   scout: boolean;
   isRead: boolean;


### PR DESCRIPTION
## 変更箇所のURL
[*島 ](http://localhost:3000/island/post/entryPermit/1)
[*イベント ](http://localhost:3000/event/post/entryPermit/2)

## やったこと

住民申請許可画面にて、許可・却下のボタンを押したらデータが変更される機能を実装

【許可】  
messagesテーブルのisReadとisAnsweredをfalseに変更、userEntryStatusに追加
【却下】
messagesテーブルのisReadとisAnsweredをfalseに変更

## やらないこと

なし

## できるようになること（ユーザ目線）

住民申請許可の処理

## できなくなること（ユーザ目線）

なし

## 動作確認

画面上にて動作確認、supabaseにてデータが変更されていることを確認

## その他

なし
