### PR TITLE
ヘッダーで参加してる島、イベントの表示

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,8 +72,8 @@ function App() {
           {/* islandフォルダ */}
           <Route path="/island/:id" element={<IslandDetail />} />
           <Route path="/island/create" element={<IslandCreate />} />
-          <Route path="/island/eventAll:id" element={<EventAll />} />
-          <Route path="/island/thread:id" element={<IslandThread />} />
+          <Route path="/island/eventAll/:id" element={<EventAll />} />
+          <Route path="/island/thread/:id" element={<IslandThread />} />
           <Route path="/island/edit" element={<IslandEdit />} />
           <Route path="/island/members/:id" element={<IslandMembers />} />
           <Route path="/island/post/:id" element={<IslandPost />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "../styles/Header.module.css";
 import { useNavigate } from "react-router-dom";
 
 import FetchJoindIslandEvent from "./hooks/FetchJoindIslandEvent";
 
 const Header = () => {
+  const [isOpenIslandList, setIsOpenIslandList] = useState(false);
+  const [isOpenEventList, setIsOpenEventList] = useState(false);
   const navigate = useNavigate();
 
-  // 参加してる島、イベントの取得
+  // 参加してる島、イベントのメッセージの取得
   const result = FetchJoindIslandEvent();
 
   // ログアウト処理
@@ -59,30 +61,67 @@ const Header = () => {
           </label>
           <nav className={styles.menu}>
             <ul className={styles.menuGroup}>
-              <li className={styles.menuGroupItem}>
-                <span className={styles.menuGroupItemLink}>参加サークル</span>
-                <ul>
+              <li className={`${styles.menuGroupItem}`}>
+                <div
+                  className={styles.menuGroupItemLinkWrapper}
+                  onClick={() => setIsOpenIslandList(!isOpenIslandList)}
+                >
+                  <span className={styles.menuGroupItemLink}>参加サークル</span>
+                </div>
+                <ul
+                  className={
+                    isOpenIslandList ? `${styles.open}` : `${styles.close}`
+                  }
+                >
                   {result.islands.map((island) => (
                     <div
                       key={island.id}
                       className={styles.listItem}
                       onClick={() => navigate(`/island/${island.id}`)}
                     >
-                      <li>{island.islandName}</li>
+                      <li>
+                        {island.islandName}
+                        {island.msgLength > 0 && (
+                          <span className={styles.msgIcon}>
+                            {island.msgLength}
+                          </span>
+                        )}
+                      </li>
                     </div>
                   ))}
                 </ul>
               </li>
+              <input
+                className={styles.checkbox}
+                type="checkbox"
+                id="checkbox"
+              />
               <li className={styles.menuGroupItem}>
-                <span className={styles.menuGroupItemLink}>参加イベント</span>
-                <ul>
+                <div
+                  className={styles.menuGroupItemLinkWrapper}
+                  onClick={() => setIsOpenEventList(!isOpenEventList)}
+                >
+                  <span className={styles.menuGroupItemLink}>参加イベント</span>
+                </div>
+                <ul
+                  className={
+                    isOpenEventList ? `${styles.open}` : `${styles.close}`
+                  }
+                >
                   {result.events.map((event) => (
                     <div
                       key={event.id}
                       className={styles.listItem}
                       onClick={() => navigate(`/event/${event.id}`)}
                     >
-                      <li>{event.eventName}</li>
+                      <li>
+                        {event.eventName}
+                        {event.msgLength > 0 && (
+                          <span className={styles.msgIcon}>
+                            {event.msgLength}
+                          </span>
+                        )}
+                      </li>
                     </div>
                   ))}
                 </ul>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import styles from "../styles/Header.module.css";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+
+import FetchJoindIslandEvent from "./hooks/FetchJoindIslandEvent";
 
 const Header = () => {
   const navigate = useNavigate();
+
+  // 参加してる島、イベントの取得
+  const result = FetchJoindIslandEvent();
+
   // ログアウト処理
   const logOutHandler = () => {
     if (document.cookie !== "") {
@@ -55,9 +61,27 @@ const Header = () => {
             <ul className={styles.menuGroup}>
               <li className={styles.menuGroupItem}>
                 <span className={styles.menuGroupItemLink}>参加サークル</span>
+                <ul>
+                  {result.islands.map((island) => (
+                    <div key={island.id} className={styles.listItem}>
+                      <a href={`/island/${island.id}`}>
+                        <li>{island.islandName}</li>
+                      </a>
+                    </div>
+                  ))}
+                </ul>
               </li>
               <li className={styles.menuGroupItem}>
                 <span className={styles.menuGroupItemLink}>参加イベント</span>
+                <ul>
+                  {result.events.map((event) => (
+                    <div key={event.id} className={styles.listItem}>
+                      <a href={`/event/${event.id}`}>
+                        <li>{event.eventName}</li>
+                      </a>
+                    </div>
+                  ))}
+                </ul>
               </li>
               <li className={styles.menuGroupItem}>
                 <a className={styles.menuGroupItemLink} href="/island/create">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -63,10 +63,12 @@ const Header = () => {
                 <span className={styles.menuGroupItemLink}>参加サークル</span>
                 <ul>
                   {result.islands.map((island) => (
-                    <div key={island.id} className={styles.listItem}>
-                      <a href={`/island/${island.id}`}>
-                        <li>{island.islandName}</li>
-                      </a>
+                    <div
+                      key={island.id}
+                      className={styles.listItem}
+                      onClick={() => navigate(`/island/${island.id}`)}
+                    >
+                      <li>{island.islandName}</li>
                     </div>
                   ))}
                 </ul>
@@ -75,10 +77,12 @@ const Header = () => {
                 <span className={styles.menuGroupItemLink}>参加イベント</span>
                 <ul>
                   {result.events.map((event) => (
-                    <div key={event.id} className={styles.listItem}>
-                      <a href={`/event/${event.id}`}>
-                        <li>{event.eventName}</li>
-                      </a>
+                    <div
+                      key={event.id}
+                      className={styles.listItem}
+                      onClick={() => navigate(`/event/${event.id}`)}
+                    >
+                      <li>{event.eventName}</li>
                     </div>
                   ))}
                 </ul>

--- a/src/components/hooks/FetchJoindIslandEvent.tsx
+++ b/src/components/hooks/FetchJoindIslandEvent.tsx
@@ -1,12 +1,12 @@
-// @ts-nocheck
 import React, { useEffect, useState } from "react";
 import { supabase } from "../../createClient";
-
+import { Island } from "../../types/members";
+import { Event } from "../../types/members";
 
 function FetchJoindIslandEvent() {
   const [island, setIsland] = useState([]);
   const [events, setEvents] = useState([]);
-  
+
   // 仮置き
   const userID = 1;
   useEffect(() => {
@@ -18,52 +18,54 @@ function FetchJoindIslandEvent() {
         .select("islands(*), events(*)")
         .eq("userID", userID);
 
-      data.map(async (join) => {
-        if (join.events === null) {
-          // 参加サークルのidを取得
-          const islandId = join.islands.id;
+      data.map(
+        async (join: { events: Event | null; islands: Island | null }) => {
+          if (join.events === null) {
+            // 参加サークルのidを取得
+            const islandId = join.islands.id;
 
-          // 参加サークルのmessagesを取得
-          const { data: post } = await supabase
-            .from("posts")
-            .select("id, messages(*)")
-            .eq("islandID", islandId);
+            // 参加サークルのmessagesを取得
+            const { data: post } = await supabase
+              .from("posts")
+              .select("id, messages(*)")
+              .eq("islandID", islandId);
 
-          // 配列で返ってくるので、index[0]から取り出す
-          const msgs = post[0].messages;
-          // 未読のメッセージを取得
-          const isReadMsg = msgs.filter((msg) => msg.isRead === false);
-          // 島名と未読メッセージの数を格納
-          const modifiedIsland = {
-            id: join.islands.id,
-            islandName: join.islands.islandName,
-            msgLength: isReadMsg.length,
-          };
-          // 配列に追加
-          tmpIsland.push(modifiedIsland);
-        } else if (join.islands === null) {
-          // 参加イベントのidを取得
-          const eventId = join.events.id;
+            // 配列で返ってくるので、index[0]から取り出す
+            const msgs = post[0].messages;
+            // 未読のメッセージを取得
+            const isReadMsg = msgs.filter((msg) => msg.isRead === false);
+            // 島名と未読メッセージの数を格納
+            const modifiedIsland = {
+              id: join.islands.id,
+              islandName: join.islands.islandName,
+              msgLength: isReadMsg.length,
+            };
+            // 配列に追加
+            tmpIsland.push(modifiedIsland);
+          } else if (join.islands === null) {
+            // 参加イベントのidを取得
+            const eventId = join.events.id;
 
-          // 参加イベントのmessagesを取得
-          const { data: post } = await supabase
-            .from("posts")
-            .select("id, messages(*)")
-            .eq("eventID", eventId);
-          // 配列で返ってくるので、index[0]から取り出す
-          const msgs = post[0].messages;
-          // 未読のメッセージを取得
-          const isReadMsg = msgs.filter((msg) => msg.isRead === false);
-          // 島名と未読メッセージの数を格納
-          const modifiedEvent = {
-            id: join.events.id,
-            eventName: join.events.eventName,
-            msgLength: isReadMsg.length,
-          };
-          // 配列に追加
-          tmpEvents.push(modifiedEvent);
-        }
-      });
+            // 参加イベントのmessagesを取得
+            const { data: post } = await supabase
+              .from("posts")
+              .select("id, messages(*)")
+              .eq("eventID", eventId);
+            // 配列で返ってくるので、index[0]から取り出す
+            const msgs = post[0].messages;
+            // 未読のメッセージを取得
+            const isReadMsg = msgs.filter((msg) => msg.isRead === false);
+            // 島名と未読メッセージの数を格納
+            const modifiedEvent = {
+              id: join.events.id,
+              eventName: join.events.eventName,
+              msgLength: isReadMsg.length,
+            };
+            // 配列に追加
+            tmpEvents.push(modifiedEvent);
+          }
+        },
+      );
       setIsland(tmpIsland);
       setEvents(tmpEvents);
     };

--- a/src/components/hooks/FetchJoindIslandEvent.tsx
+++ b/src/components/hooks/FetchJoindIslandEvent.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from "react";
+import { supabase } from "../../createClient";
+
+function FetchJoindIslandEvent() {
+  const [island, setIsland] = useState([]);
+  const [events, setEvents] = useState([]);
+  // 仮置き
+  const userID = 1;
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      let tmpIsland = [];
+      let tmpEvents = [];
+      let { data } = await supabase
+        .from("userEntryStatus")
+        .select("islands(*), events(*)")
+        .eq("userID", userID);
+      data.map((join) => {
+        if (join.events === null) {
+          tmpIsland.push(join.islands);
+        } else if (join.islands === null) {
+          tmpEvents.push(join.events);
+        }
+      });
+      setIsland(tmpIsland);
+      setEvents(tmpEvents);
+    };
+    fetchUserInfo();
+  }, []);
+  return { islands: island, events: events };
+}
+
+export default FetchJoindIslandEvent;

--- a/src/styles/Header.module.css
+++ b/src/styles/Header.module.css
@@ -9,10 +9,6 @@ header {
   align-items: flex-end;
 }
 
-.headerItem div {
-  margin-right: 10px;
-}
-
 .headerItem .hambuger {
   margin-right: 0;
 }
@@ -22,13 +18,29 @@ header {
   height: 50px;
 }
 
+.listItem {
+  list-style: none;
+  margin-bottom: 10px;
+}
+.listItem a {
+  text-decoration: none;
+  color: #000;
+}
+.listItem a:hover {
+  text-decoration: underline;
+}
+
+.menu ul{
+  padding-inline-start: 0px;
+}
+
 /* ハンバーガーメニューの関する記述 */
 .hambuger {
   justify-items: baseline;
 }
 
 .menu {
-  position: fixed;
+  position: absolute;
   right: -30vw;
   width: 25vw;
   height: 70vh;
@@ -50,13 +62,12 @@ header {
   width: 100%;
   flex: auto;
   padding: 4px;
+  text-align: center;
+  margin-bottom: 1rem;
 }
 .menuGroupItemLink {
   padding: 0.5em 0.5em;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: wrap;
+  text-align: center;
   font-size: 18px;
   font-weight: bold;
   letter-spacing: 0.02em;

--- a/src/styles/Header.module.css
+++ b/src/styles/Header.module.css
@@ -28,8 +28,35 @@ header {
   text-decoration: underline;
 }
 
-.menu ul{
+.menu ul {
   padding-inline-start: 0px;
+}
+
+.menuGroupItemLinkWrapper {
+  cursor: pointer;
+}
+
+/* 参加してる島、イベントの表示・非表示 */
+.open {
+  display: block;
+}
+
+.close {
+  display: none;
+}
+
+/* メッセージアイコン */
+.msgIcon {
+  display: inline-block;
+  margin-left: 1rem;
+  width: 20px;
+  height: 20px;
+  padding: 3px;
+  color: #fff;
+  border: 1px solid #172a22;
+  background-color: #172a22;
+  border-radius: 50%;
+  text-align: center;
 }
 
 /* ハンバーガーメニューの関する記述 */

--- a/src/styles/Header.module.css
+++ b/src/styles/Header.module.css
@@ -21,12 +21,10 @@ header {
 .listItem {
   list-style: none;
   margin-bottom: 10px;
+  cursor: pointer;
 }
-.listItem a {
-  text-decoration: none;
-  color: #000;
-}
-.listItem a:hover {
+
+.listItem:hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## 変更箇所のURL

## やったこと
- ログインしているユーザーの参加島、イベントの表示
- 未読メッセージ数の表示
- CSSの修正

## やらないこと
なし
## できるようになること（ユーザ目線）
- 参加島、イベントのトップページに遷移

## できなくなること（ユーザ目線）
なし

## 動作確認
ページ遷移

## その他
