### PR TITLE
住民申請機能実装

### DIFF
--- a/src/components/modalWindows/createResidentApplication.tsx
+++ b/src/components/modalWindows/createResidentApplication.tsx
@@ -1,40 +1,104 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styles from "../../styles/createSendingMessage.module.css";
+import { supabase } from "../../createClient";
+import { useParams } from "react-router-dom";
 
 export default function CreateResidentApplication({
-    closeResidentModal,
+  closeResidentModal,
+  table,
 }: {
-    closeResidentModal: () => void;
+  closeResidentModal: () => void;
+  table: string;
 }) {
-    const addHandler = () => {};
-    return(
-        <>
-            <div className={styles.overlay}>
-                <div className={styles.modal}>
-                    <div className={styles.allContents}>
-                        <img
-                        src="/modalWindow/close.png"
-                        alt="×ボタン"
-                        onClick={closeResidentModal}
-                        className={styles.close}
-                        />
-                        <div className={styles.main}>
-                        <div className={styles.title}>
-                            <h3 className={styles.h3}>○○島</h3>
-                            <p className={styles.messageName}>住民申請</p>
-                        </div>
-                        <div className={styles.input}>
-                            <label htmlFor="threadName">コメント</label><br />
-                            <textarea name="text" className={styles.textSending}></textarea>
-                        </div>
-                        </div>
-                        <div className={styles.btn}>
-                        <button onClick={addHandler}>送信する</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
+  const params = useParams();
+  const paramsID = parseInt(params.id);
+  const [message, setMessage] = useState("");
+  const [postedID, setPostedID] = useState(null);
 
-        </>
-    );
+  useEffect(() => {
+    fetchPost();
+  }, []);
+
+  const fetchPost = async () => {
+    // PostedByに入れるため、送信する側のPostIDを取得する
+    const { data: postedBy, error: postedByError } = await supabase
+      .from("posts")
+      .select("id")
+      .eq(`${table}ID`, paramsID)
+      .eq("status", false);
+    if (postedByError) {
+      console.log(postedByError, "エラー");
+    }
+    setPostedID(postedBy[0].id);
+  };
+
+
+  // messagesテーブルとapplicationsテーブルにメッセージを保存
+  const saveMessage = async () => {
+    try {
+      const { data: messagesData, error: messagesError } = await supabase
+        .from("messages")
+        .insert([
+          {
+            postID: postedID,
+            message: message,
+            scout: true,
+            isRead: false,
+            isAnswered: false,
+            postedBy: postedID,
+            status: false,
+          },
+        ]);
+
+
+      if (messagesError) {
+        console.error("メッセージの送信中にエラーが発生しました:");
+      } else {
+        console.log("データが正常に送信されました");
+        closeResidentModal();
+      }
+    } catch (error) {
+      console.error("データの送信中にエラーが発生しました:", error.message);
+    }
+  };
+
+  const addHandler = () => {
+    saveMessage();
+  };
+
+  return (
+    <>
+      <div className={styles.overlay}>
+        <div className={styles.modal}>
+          <div className={styles.allContents}>
+            <img
+              src="/modalWindow/close.png"
+              alt="×ボタン"
+              onClick={closeResidentModal}
+              className={styles.close}
+            />
+            <div className={styles.main}>
+              <div className={styles.title}>
+                <h3 className={styles.h3}>○○島</h3>
+                <p className={styles.messageName}>住民申請</p>
+              </div>
+              <div className={styles.input}>
+                <label htmlFor="threadName">コメント</label>
+                <br />
+                <textarea
+                  name="text"
+                  className={styles.textSending}
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                ></textarea>
+              </div>
+            </div>
+            <div className={styles.btn}>
+              <button onClick={addHandler}>送信する</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
 }

--- a/src/components/modalWindows/createSendingScout.tsx
+++ b/src/components/modalWindows/createSendingScout.tsx
@@ -1,5 +1,5 @@
 import styles from "../../styles/createSendingScout.module.css";
-import ComboBox from "../comboBox";
+// import ComboBox from "../comboBox";
 import { supabase } from "../../createClient";
 import { useEffect, useState } from "react";
 import { newUsersData } from "../../types/sendScout";

--- a/src/island/[id].tsx
+++ b/src/island/[id].tsx
@@ -74,7 +74,7 @@ export default function IslandDetail() {
 
             <div className={styles.btn}>
               <button onClick={openResindentModal}>住民申請</button>
-              {isResidentOpen && <CreateResidentApplication closeResidentModal={closeResidentModal} />}
+              {isResidentOpen && <CreateResidentApplication closeResidentModal={closeResidentModal} table="island" />}
               <button onClick={openModal}>メッセージを送る</button>
               {isOpen && <CreateSendingMessage closeModal={closeModal} />}
             </div>


### PR DESCRIPTION
## 変更箇所のURL

* 住民申請機能（モーダルウィンドウ）実装
- 住民申請コメント入力画面
<img width="1440" alt="スクリーンショット 2023-05-29 15 50 15" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/baa20a66-6daf-4bec-abe3-b8baf7c81d2b">
- 送信ボタンを押下した後のコンソール
<img width="1440" alt="スクリーンショット 2023-05-29 15 50 53" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/c69a46c1-6d4f-47f3-86c8-8f8b2f911005">
- messagesテーブルに送信したコメントがpost（確認画面）
<img width="1440" alt="スクリーンショット 2023-05-29 15 51 35" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/45045db5-cfee-4327-bb54-b943d558b628">

## やったこと

* ユーザーが入力したコメントをmessagesテーブルにpost

## やらないこと

* 特になし

## できるようになること（ユーザ目線）

* 入りたいサークル宛に住民申請を送ることが可能（コメントあり）

## できなくなること（ユーザ目線）

* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* applicationsテーブルにデータをpostしたいが、messageIDの付与をどのように行うか（uuidで生成？？）