### PR TITLE
Feature/quitFn

### DIFF
--- a/src/components/modalWindows/quitConf.tsx
+++ b/src/components/modalWindows/quitConf.tsx
@@ -1,16 +1,56 @@
 import { useState } from "react";
 import styles from "../../styles/modalWindows/quit.module.css";
-import QuitDone from "./quitDone";
+import GetCookieID from "../cookie/getCookieId";
+import { supabase } from "../../createClient";
 
 export default function QuitConf({
   close2Modal,
   nextOpen2,
+  inputValue,
+  setInputValue,
 }: {
   close2Modal: () => void;
   nextOpen2: () => void;
+  inputValue: string;
+  // React.Dispatch<>は、<>の値を引数として受け取る
+  setInputValue: React.Dispatch<React.SetStateAction<string>>;
 }) {
-  const nextHandler = () => {
-    nextOpen2();
+  const userId = GetCookieID();
+  const [emptyChara, setEmptyChara] = useState("");
+  const [notExist, setNotExist] = useState("");
+
+  const nextHandler = async () => {
+    if (inputValue) {
+      const { data } = await supabase
+        .from("users")
+        .select("familyName, firstName")
+        .eq("id", userId);
+
+      if (data && data.length > 0) {
+        const familyName = data[0].familyName;
+        const firstName = data[0].firstName;
+
+        const fullName = familyName + firstName;
+
+        if (fullName !== inputValue) {
+          setNotExist("入力された名前が間違っています");
+        } else {
+          nextOpen2();
+        }
+      }
+    }
+  };
+
+  const handleInputChange = async (event) => {
+    const value = event.target.value;
+    if (/\s/.test(value)) {
+      // 空白文字（\s）を入れようとした場合、エラーメッセージを表示
+      setEmptyChara("空白文字は入力できません");
+      setNotExist("");
+    } else {
+      setInputValue(value);
+      setEmptyChara("");
+    }
   };
 
   return (
@@ -32,15 +72,32 @@ export default function QuitConf({
                 <p>
                   削除するために下記のテキストボックスに名前をフルネームで入力してください
                 </p>
-                <p>※苗字と名前の間にスペースを入れずに入力してください</p>
+                <p>※姓と名の間にスペースを入れずに入力してください</p>
               </div>
               <div>
-                <input type="text"></input>
+                <input
+                  type="text"
+                  value={inputValue}
+                  onChange={handleInputChange}
+                ></input>
+
+                {emptyChara && (
+                  <div>
+                    <span className={styles.spanB}>{emptyChara}</span>
+                  </div>
+                )}
+                {notExist && (
+                  <div>
+                    <span className={styles.span}>{notExist}</span>
+                  </div>
+                )}
               </div>
             </div>
 
             <div>
-              <button onClick={nextHandler}>アカウントを削除する</button>
+              <button onClick={nextHandler} disabled={!inputValue.trim()}>
+                アカウントを削除する
+              </button>
             </div>
           </div>
         </div>

--- a/src/styles/modalWindows/quit.module.css
+++ b/src/styles/modalWindows/quit.module.css
@@ -27,3 +27,17 @@
   height: 50%;
   position: relative;
 }
+
+.close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.span {
+  color: red;
+}
+
+.spanB {
+  color: blue;
+}

--- a/src/user/edit.tsx
+++ b/src/user/edit.tsx
@@ -4,6 +4,8 @@ import QuitUser from "../components/modalWindows/quitUser";
 import QuitConf from "../components/modalWindows/quitConf";
 import { useNavigate } from "react-router-dom";
 import QuitDone from "../components/modalWindows/quitDone";
+import GetCookieID from "../components/cookie/getCookieId";
+import { supabase } from "../createClient";
 
 export default function UserEdit() {
   LogSt();
@@ -12,8 +14,11 @@ export default function UserEdit() {
   const [isOpen, setIsOpen] = useState(false);
   const [confOpen, setConfOpen] = useState(false);
   const [lastOpen, setLastOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
 
-  // モーダルウィンドウの開閉(アカウントを削除しますか？)
+  const userId = GetCookieID();
+
+  // アカウントを削除しますか？ウィンドウを開く
   const openModal = () => {
     setIsOpen(true);
   };
@@ -39,18 +44,73 @@ export default function UserEdit() {
     setConfOpen(false);
   };
 
-  // 削除完了ウィンドウを閉じる
-  const done = () => {
+  // 削除完了ウィンドウを閉じると、データが論理削除されて新規登録画面に遷移する
+  const done = async () => {
     setLastOpen(false);
-    navigate("/user/newUser");
-    window.location.reload();
+
+    // posts・users・userEntryStatusテーブルのstatusをtrueに変更
+    const { data, error } = await supabase
+      .from("users")
+      .select("familyName, firstName")
+      .eq("id", userId);
+
+    if (error) {
+      console.error("Error fetching user data:", error);
+    }
+    if (data && data.length > 0) {
+      const familyName = data[0].familyName;
+      const firstName = data[0].firstName;
+
+      const fullName = familyName + firstName;
+
+      if (fullName === inputValue) {
+        const { error: usersError } = await supabase
+          .from("users")
+          .update({ status: "true" })
+          .eq("id", userId);
+
+        const { error: userEnError } = await supabase
+          .from("userEntryStatus")
+          .update({ status: "true" })
+          .eq("userID", userId);
+
+        const { error: postsError } = await supabase
+          .from("posts")
+          .update({ status: "true" })
+          .eq("userID", userId);
+
+        if (usersError || userEnError || postsError) {
+          console.error(
+            "Error changing status :",
+            usersError || userEnError || postsError,
+          );
+          // cookie情報の削除
+          if (document.cookie !== "") {
+            let expirationDate = new Date("1999-12-31T23:59:59Z");
+            document.cookie = `id=; expires=${expirationDate.toUTCString()}; path=/;`;
+            document.cookie = `loginSt=; expires=${expirationDate.toUTCString()}; path=/;`;
+          }
+        }
+
+        console.log("Change status of user successfully.");
+        navigate("/user/newUser");
+        window.location.reload();
+      }
+    }
   };
 
   return (
     <>
       <button onClick={openModal}>退会</button>
       {isOpen && <QuitUser closeModal={closeModal} nextOpen={nextOpen} />}
-      {confOpen && <QuitConf close2Modal={close2Modal} nextOpen2={nextOpen2} />}
+      {confOpen && (
+        <QuitConf
+          close2Modal={close2Modal}
+          nextOpen2={nextOpen2}
+          inputValue={inputValue}
+          setInputValue={setInputValue}
+        />
+      )}
       {lastOpen && <QuitDone done={done} />}
     </>
   );

--- a/src/user/newUser.tsx
+++ b/src/user/newUser.tsx
@@ -1,5 +1,19 @@
-import React from "react";
+import React, { useEffect } from "react";
+import LogSt from "../components/cookie/logSt";
+import { useNavigate } from "react-router-dom";
+import { useCookies } from "react-cookie";
 
 export default function NewUser() {
+  const navigate = useNavigate();
+  const [loginStatus] = useCookies(["loginSt"]);
+
+  // ログイン済みの場合、トップページにリダイレクト
+  useEffect(() => {
+    const status = loginStatus.loginSt;
+    if (status == "true") {
+      navigate("/");
+      window.location.reload();
+    }
+  }, []);
   return <></>;
 }


### PR DESCRIPTION
## 変更箇所のURL

- src/components/quitConf.tsx
- src/user/edit.tsx

## やったこと

### 退会機能の実装
#### ・posts・users・userEntryStatusテーブルのstatusをtrueに変更することで、アカウントの論理削除実行(user/edit.tsx)
同時にcookie情報もログアウトと同じように削除しています。

#### ・退会小窓画面の×ボタンの配置を変更
####  ・退会入力小窓画面で入力内容のチェック機能

##### 未入力時はアカウント削除ボタンをグレーアウト
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/520085e9-ed9b-40f7-a287-35bca153de1a)

##### 空白文字を入力できないよう設定（しようとすると青文字で「空白文字は入力できません」の表示が出る）
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/296f8d79-042e-49e3-9bcf-1f277132703d)

##### 「アカウント削除」ボタンが押されたときに、入力内容がログインユーザーの名前と一致しない場合、エラーが表示され画面遷移を実行しない
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/bac06b0d-a711-4977-be94-54a16ad7e85c)


## やらないこと

CSS

## できるようになること（ユーザ目線）

退会処理

## できなくなること（ユーザ目線）

無

## 動作確認

supabaseにてposts、userEntryStatus、usersテーブルがすべてfalseになるのを確認

## その他


