### PR TITLE
サークル一覧画面・機能作成

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,7 @@ function App() {
             path="/island/message/user_message"
             element={<UserMessage />}
           />
-          <Route path="/island/eventAll" element={<IslandAll />} />
+          <Route path="/island/islandAll" element={<IslandAll />} />
           {/* eventフォルダ */}
           <Route path="/event/:id" element={<EventDetail />} />
           <Route path="/event/create/:id" element={<EventCreate />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -186,6 +186,14 @@ const Header = () => {
                   あなたのポスト
                 </a>
               </li>
+              <li className={styles.menuGroupItem}>
+                <a
+                  className={styles.menuGroupItemLink}
+                  href="/island/islandAll"
+                >
+                  サークル一覧
+                </a>
+              </li>
             </ul>
           </nav>
         </div>

--- a/src/island/eventAll.tsx
+++ b/src/island/eventAll.tsx
@@ -122,6 +122,3 @@ export default function EventAll() {
     </div>
   );
 }
-function eq(arg0: string, arg1: string) {
-  throw new Error("Function not implemented.");
-}

--- a/src/island/eventAll.tsx
+++ b/src/island/eventAll.tsx
@@ -9,13 +9,32 @@ export default function EventAll() {
   LogSt();
   const navigate = useNavigate();
   const params = useParams();
-  const [events, setEvents] = useState([]);
   const paramsID = params.id;
+  const [events, setEvents] = useState([]);
+  const [islandName, setIslandName] = useState("");
+
   const currentDateTime = new Date(); // 現在の日時取得
 
   const createHandler = () => {
     navigate("/event/create/[id]");
     window.location.reload();
+  };
+
+  // 島の名前を取得する関数
+  const fetchIslandName = async () => {
+    const { data, error } = await supabase
+      .from("islands")
+      .select("islandName")
+      .eq("id", paramsID);
+
+    if (error) {
+      console.error("islandsテーブルデータ情報取得失敗", error);
+      return;
+    }
+
+    if (data && data.length > 0) {
+      setIslandName(data[0].islandName);
+    }
   };
 
   useEffect(() => {
@@ -38,7 +57,8 @@ export default function EventAll() {
         const { data: eventData, error: eventError } = await supabase
           .from("events")
           .select("*")
-          .eq("id", eventId);
+          .eq("id", eventId)
+          .eq("status", "false");
 
         if (eventError) {
           console.error("Eventsテーブルデータ情報取得失敗", eventError);
@@ -53,13 +73,14 @@ export default function EventAll() {
       setEvents(fetchedEvents.filter((event) => event !== null));
     };
 
+    fetchIslandName();
     fetchEventData();
   }, [paramsID]);
   return (
     <div className={styles.flex}>
       <MenubarIsland />
       <div className={styles.all}>
-        <h2>○○島の掲示板</h2>
+        <h2>{islandName}島 開催イベント</h2>
         <button onClick={createHandler} className={styles.button}>
           新しいイベントを始める
         </button>
@@ -100,4 +121,7 @@ export default function EventAll() {
       </div>
     </div>
   );
+}
+function eq(arg0: string, arg1: string) {
+  throw new Error("Function not implemented.");
 }

--- a/src/island/islandAll.tsx
+++ b/src/island/islandAll.tsx
@@ -1,16 +1,70 @@
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import LogSt from "../components/cookie/logSt";
 import styles from "../styles/island/all.module.css";
 import { supabase } from "../createClient";
 import MenubarIsland from "../components/menubarIsland";
+import { useEffect, useState } from "react";
 
 export default function IslandAll() {
   LogSt();
   const navigate = useNavigate();
+  const params = useParams();
+  const paramsID = params.id;
+
+  const [islands, setIslands] = useState([]);
+
+  // 島のデータを取得する関数
+  const fetchIslandsData = async () => {
+    const { data, error } = await supabase
+      .from("islands")
+      .select("*")
+      .eq("status", "false");
+
+    if (error) {
+      console.error("islandsテーブルデータ情報取得失敗", error);
+      return;
+    }
+
+    setIslands(data);
+  };
+  useEffect(() => {
+    fetchIslandsData();
+  }, []);
+
+  // 「活動用内容」100文字以降は...で表示する
+  const truncateString = (str, maxLength) => {
+    if (str.length > maxLength) {
+      return str.slice(0, maxLength) + "...";
+    } else {
+      return str;
+    }
+  };
+
   return (
     <div className={styles.flex}>
       <MenubarIsland />
-      <div className={styles.all}></div>
+      <div className={styles.all}>
+        <h2>島一覧</h2>
+        <div className={styles.eventAll}>
+          {islands.map((island) => (
+            <div key={island.id} className={styles.event1}>
+              <div className={styles.imgSide}>
+                <img
+                  className={styles.icon}
+                  src={island.thumbnail || "/island/island_icon.png"}
+                  alt="island Thumbnail"
+                ></img>
+                <div className={styles.eventInfo}>
+                  <Link to={`/island/${paramsID}`}>
+                    <h2 className={styles.eventName}>{island.islandName}</h2>
+                  </Link>
+                  <p>{truncateString(island.detail, 100)}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 変更箇所のURL

- src/island/eventAll.tsx
- src/island/islandAll.tsx

## やったこと

### イベント一覧画面一部変更
・島名の表示し忘れていたので修正
・イベントのstatusがfalseの状態のもののみデータを持ってくるよう修正（trueも持ってきちゃっていた）
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/d3d236e7-0db8-43ec-8216-161e59ea712b)

### ハンバーガーメニューに「サークル一覧」項目の追加
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/cda9a1f5-8929-481b-91a7-3580ab5fb357)



### サークル一覧画面と機能の実装
・サークルのstatusがfalseのもののみすべて表示
・サークルの活動内容部分は100文字以上ある場合、100文字まで表示し、それ以降は「…」で表示されるよう設定

![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/432a0850-4bff-478a-89b8-bf6b98679993)
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/1a761672-952e-47d0-aa24-25a79130d6d8)


## やらないこと

- CSS

## できるようになること（ユーザ目線）

島一覧閲覧

## できなくなること（ユーザ目線）

無

## 動作確認


## その他


