### PR TITLE
Feature/userPost

### DIFF
--- a/src/event/post.tsx
+++ b/src/event/post.tsx
@@ -37,8 +37,7 @@ export default function EventPost() {
         .from("messages")
         .select("*, applications(*)")
         .eq("postID", postID)
-        .eq("status", false)
-        .eq("isRead", false);
+        .eq("status", false);
 
       // applicationsにデータがある場合は排除（住民許可申請は表示させない）
       let msgs = msgsUnfil.filter(function (ms) {
@@ -111,6 +110,7 @@ export default function EventPost() {
             messages.map((message) => (
               <div className={styles.message} key={message.id}>
                 <div className={styles.flex}>
+                  <div className={styles.unreadCircle}></div>
                   <img
                     src={
                       message.by.users.icon ||

--- a/src/island/post.tsx
+++ b/src/island/post.tsx
@@ -39,14 +39,10 @@ export default function IslandPost() {
         .eq("postID", postID)
         .eq("status", false);
 
-      console.log(msgsUnfil);
-
       // applicationsにデータがある場合は排除（住民許可申請は表示させない）
       let msgs = msgsUnfil.filter(function (ms) {
         return ms.applications.length === 0;
       });
-
-      console.log(msgs);
 
       if (msgError) {
         console.error("msg情報取得失敗");

--- a/src/island/post.tsx
+++ b/src/island/post.tsx
@@ -39,10 +39,14 @@ export default function IslandPost() {
         .eq("postID", postID)
         .eq("status", false);
 
+      console.log(msgsUnfil);
+
       // applicationsにデータがある場合は排除（住民許可申請は表示させない）
       let msgs = msgsUnfil.filter(function (ms) {
         return ms.applications.length === 0;
       });
+
+      console.log(msgs);
 
       if (msgError) {
         console.error("msg情報取得失敗");

--- a/src/styles/island/island_post.module.css
+++ b/src/styles/island/island_post.module.css
@@ -61,6 +61,19 @@
   margin-top: 0;
 }
 
+/* 未読の場合のCSS */
 .unread {
-  color: rgb(0, 161, 209);
+  font-weight: bold;
+}
+
+.unreadCircle {
+  display: inline-block;
+  padding: 0.2em 0.5em;
+  background-color: #6cdff6;
+  border-radius: 1em;
+  margin-right: 0.5em;
+}
+
+.unreadName {
+  font-weight: bold;
 }

--- a/src/user/post.tsx
+++ b/src/user/post.tsx
@@ -1,17 +1,22 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import styles from "../styles/user/user_post.module.css";
+import { Link, useNavigate } from "react-router-dom";
+import styles from "../styles/island/island_post.module.css";
 import { supabase } from "../createClient";
 import GetCookieID from "../components/cookie/getCookieId";
+import { format } from "date-fns";
+import classNames from "classnames";
+import LogSt from "../components/cookie/logSt";
 
 export default function UserPost() {
-  const [island, setIsland] = useState([]);
-  const [events, setEvent] = useState([]);
+  LogSt();
+  const [messages, setMessages] = useState([]);
 
   const userID = GetCookieID();
+  const navigate = useNavigate();
 
   //メッセージ受信
   const fetchMsg = async () => {
+    // ログインユーザーのポスト番号取得
     const { data, error } = await supabase
       .from("posts")
       .select("id")
@@ -22,10 +27,13 @@ export default function UserPost() {
       console.error("post情報取得失敗");
     } else {
       const postID = data[0].id;
+
+      // ユーザーのポストに入っているメッセ情報取得
       const { data: msgs, error: msgError } = await supabase
         .from("messages")
         .select("*")
-        .eq("postID", postID);
+        .eq("postID", postID)
+        .eq("status", false);
 
       if (msgError) {
         console.error("msg情報取得失敗");
@@ -33,40 +41,37 @@ export default function UserPost() {
         if (msgs.length > 0) {
           // 受信しているメッセージがあるときのみ実行
           //msgsのオブジェクトデータごとにpostedByの検索をかける
-          msgs.map(async (msg) => {
+          const promises = msgs.map(async (msg) => {
             const postID = msg.postedBy;
             const { data: by, error: byError } = await supabase
               .from("posts")
               .select("*, events(*), islands(*)")
               .eq("id", postID)
               .eq("status", false);
-            // console.log(by);
 
             if (byError) {
               console.error("送信者取得失敗");
             } else {
               if (by.length > 0) {
-                // 送信者がイベントのメッセージ一覧
-                if (by[0].islands === null) {
-                  const eventObject = {
-                    ...msg,
-                    by: by[0],
-                  };
-                  console.log(eventObject);
-                  return eventObject;
-
-                  // 送信者が島のメッセージ一覧
-                } else if (by[0].events === null) {
-                  const islandObject = {
-                    ...msg,
-                    by: by[0],
-                  };
-                  console.log(islandObject);
-                  return islandObject;
-                }
+                const Object = {
+                  ...msg,
+                  by: by[0],
+                };
+                return Object;
               }
             }
           });
+
+          Promise.all(promises)
+            .then((results) => {
+              const Objects = results.filter((result) => result !== undefined);
+
+              console.log(Objects);
+              setMessages(Objects);
+            })
+            .catch((error) => {
+              console.error("メッセージ情報取得失敗", error);
+            });
         } else {
           console.log("受信メッセージはありません");
         }
@@ -78,6 +83,19 @@ export default function UserPost() {
     fetchMsg();
   }, []);
 
+  // 既読に変更し、メッセージ全文確認ページへ遷移
+  const readHandler = async (messageId) => {
+    const { error } = await supabase
+      .from("messages")
+      .update({ isRead: true })
+      .eq("id", messageId);
+    if (error) {
+      console.error("Failed to update 'isRead' field:", error);
+    } else {
+      navigate(`/island/message/islandPostMessage/${messageId}`);
+    }
+  };
+
   return (
     <>
       <div className={styles.userPostBack}>
@@ -85,24 +103,55 @@ export default function UserPost() {
         <div className={styles.postMessageBack}>
           <h2>受信メッセージ✉️</h2>
 
-          {/* {islandsMs.map((island) => (
-            <div className={styles.message}>
-              <div className={styles.flex}>
-                <img
-                  className={styles.icon}
-                  src={island.thumbnail || "/island/island_icon.png"}
-                  alt="island Thumbnail"
-                ></img>
-                <div className={styles.right}>
-                  <p className={styles.name}> {island.islandName}</p>
-                  <p>テキストテキストテキストテキストテキストテキスト...</p>
+          {messages.length === 0 ? (
+            <p>受信メッセージはありません</p>
+          ) : (
+            messages.map((message) => (
+              <div className={styles.message}>
+                <div className={styles.flex}>
+                  <img
+                    className={styles.icon}
+                    src={
+                      (message.by.events && message.by.events.thumbnail) ||
+                      (message.by.islands && message.by.islands.thumbnail) ||
+                      "https://tfydnlbfauusrsxxhaps.supabase.co/storage/v1/object/public/userIcon/tanuki.PNG1351?t=2023-06-08T07%3A12%3A33.854Z"
+                    }
+                    alt=" Thumbnail"
+                  ></img>
+                  <div className={styles.right}>
+                    <div className={styles.circleSide}>
+                      <p
+                        className={classNames(styles.name, {
+                          [styles.unreadName]: !message.isRead,
+                        })}
+                      >
+                        {message.isRead === false && (
+                          <div className={styles.unreadCircle}>未読</div>
+                        )}
+                        <span>
+                          {(message.by.islands &&
+                            message.by.islands.islandName) ||
+                            (message.by.events && message.by.events.eventName)}
+                        </span>
+                      </p>
+                    </div>
+                    <p
+                      className={classNames({
+                        [styles.unread]: !message.isRead,
+                      })}
+                    >
+                      ＞ {message.message}
+                    </p>
+                    <p>
+                      {format(new Date(message.sendingDate), "yyyy年MM月dd日")}
+                    </p>
+                  </div>
                 </div>
+
+                <button onClick={() => readHandler(message.id)}>表示</button>
               </div>
-              <Link to={`/user/message/island_message/${island.id}`}>
-                <button>表示</button>
-              </Link>
-            </div>
-          ))} */}
+            ))
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
## 変更箇所のURL

- src/user/post.tsx

## やったこと

### 個人用ポストの実装
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/354d89c3-9d2b-4be2-894b-701423ac7243)
・未読時に「未読」アイコンと、文字を太文字にして表示
・サークル・イベント・スカウトのメッセージを受信


## やらないこと

- 各メッセージの遷移先指定（全文表示画面終了後に再実装します）
- CSS

## できるようになること（ユーザ目線）

個人用ポストの閲覧

## できなくなること（ユーザ目線）

無

## 動作確認

画面上

## その他


