### PR TITLE
Feature/noDobleapplication

### DIFF
--- a/src/island/[id].tsx
+++ b/src/island/[id].tsx
@@ -6,13 +6,16 @@ import CreateResidentApplication from "../components/modalWindows/createResident
 import { useNavigate, useParams } from "react-router-dom";
 import { supabase } from "../createClient";
 import LogSt from "../components/cookie/logSt";
+import GetCookieID from "../components/cookie/getCookieId";
 
 export default function IslandDetail() {
   LogSt();
   const [isOpen, setIsOpen] = useState(false);
+  const [alreadyError, setAlreadyError] = useState("");
   const [isResidentOpen, setIsResidentOpen] = useState(false);
   const navigate = useNavigate();
   const islandId = useParams();
+  const userId = GetCookieID();
   const [islandDetail, setIslandDetail] = useState(null); // 取得した島の詳細情報を保持する状態変数
   const [islandImage, setIslandImage] = useState(
     "https://tfydnlbfauusrsxxhaps.supabase.co/storage/v1/object/public/userIcon/tanuki.PNG1351?t=2023-06-05T07%3A40%3A07.886Z",
@@ -20,6 +23,7 @@ export default function IslandDetail() {
 
   useEffect(() => {
     fetchIslandDetail();
+    fetchIslandPost();
   }, []);
 
   const fetchIslandDetail = async () => {
@@ -41,6 +45,47 @@ export default function IslandDetail() {
     setIslandDetail(islandDetail); // 島の詳細情報を状態変数にセット
     if (islandDetail.thumbnail) {
       setIslandImage(islandDetail.thumbnail);
+    }
+  };
+
+  // すでに住民申請を送っているか確認確認
+  const fetchIslandPost = async () => {
+    // ユーザーのポスト番号取得
+    const { data, error } = await supabase
+      .from("posts")
+      .select("id")
+      .eq("userID", userId)
+      .eq("status", false);
+
+    if (error) {
+      console.log("ユーザーポスト番号取得失敗");
+    }
+    // ユーザーが送信したメッセージ取得
+    const { data: message, error: messageError } = await supabase
+      .from("messages")
+      .select("*")
+      .eq("postedBy", data[0].id);
+
+    const appMsg = message.filter((msg) => msg.message === "参加申請");
+
+    // 島ポスト番号取得
+    if (appMsg.length > 0) {
+      const { data: island, error: islandError } = await supabase
+        .from("posts")
+        .select("*")
+        .eq("islandID", Number(islandId.id));
+
+      if (islandError) {
+        console.log("島ポスト番号取得失敗");
+      }
+
+      // 島ポスト番号が送信済みの参加申請のpostIDと同じだった場合に「住民申請」ボタンをグレーアウトし、「すでに申請済みです」のエラーを表示させる
+      if (appMsg[0].postID === island[0].id) {
+        setAlreadyError("すでに住民許可申請を送っています");
+      }
+    }
+    if (messageError) {
+      console.log("ユーザー送信メッセージ一覧取得失敗");
     }
   };
 
@@ -85,7 +130,16 @@ export default function IslandDetail() {
             {islandDetail && islandDetail.detail}
           </p>
           <div>
-            <button onClick={openResindentModal} className={styles.btn1}>
+            {alreadyError && (
+              <div>
+                <span className={styles.span}>{alreadyError}</span>
+              </div>
+            )}
+            <button
+              onClick={openResindentModal}
+              className={`${styles.btn1} ${alreadyError && styles.disabled}`}
+              disabled={alreadyError ? true : false}
+            >
               住民申請
             </button>
             {isResidentOpen && (

--- a/src/styles/island/islandDetail.module.css
+++ b/src/styles/island/islandDetail.module.css
@@ -111,3 +111,13 @@
   width: 90%;
   margin: auto;
 }
+
+/* すでに住民許可申請を送っている場合 */
+.span {
+  color: red;
+}
+
+.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}


### PR DESCRIPTION
## 変更箇所のURL

- src/island/[id].tsx
- src/event/[id].tsx

## やったこと

### 住民申請を送信済みの島の詳細画面に「すでに住民申請を送っています」の表示と「住民申請」ボタンをグレーアウト表示
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/f7ff2b5f-a720-4fca-b12d-9a8d6e45d45b)
※イベントの場合は難民のみ表示される状態（すでに参加している人はボタンをグレーアウトする予定なので、難民のみ実装済み）

## やらないこと

島・イベントに参加済みの場合のエラー表示

## できるようになること（ユーザ目線）
無

## できなくなること（ユーザ目線）

２回住民申請送信することは不可（1回目拒否された場合も不可（送ったことがある時点で不可）にしています）

## 動作確認

画面確認

## その他

