### PR TITLE
Feature/ownerSet

### DIFF
--- a/src/event/create.tsx
+++ b/src/event/create.tsx
@@ -8,6 +8,7 @@ import Daytime from "../components/createEvent/daytime";
 import { supabase } from "../createClient";
 import SelectIsland from "../components/selectIsland";
 import MenubarIsland from "../components/menubarIsland";
+import GetCookieID from "../components/cookie/getCookieId";
 
 export default function EventCreate() {
   LogSt();
@@ -25,6 +26,7 @@ export default function EventCreate() {
   const params = useParams();
   const paramsID = parseInt(params.id);
   const islandID = params.id;
+  const ownerID = GetCookieID();
 
   // 画像ファイル選択したら、表示画像に反映
   const handleFileChange = async (
@@ -56,6 +58,7 @@ export default function EventCreate() {
       detail: detail,
       startDate: new Date(startDate).toISOString(),
       endDate: new Date(endDate).toISOString(),
+      ownerID: ownerID,
       status: false,
       createdBy: "システム",
       thumbnail: imageUrl,

--- a/src/island/[id].tsx
+++ b/src/island/[id].tsx
@@ -16,6 +16,7 @@ export default function IslandDetail() {
   const navigate = useNavigate();
   const islandId = useParams();
   const userId = GetCookieID();
+  const [button, setButton] = useState(true);
   const [islandDetail, setIslandDetail] = useState(null); // 取得した島の詳細情報を保持する状態変数
   const [islandImage, setIslandImage] = useState(
     "https://tfydnlbfauusrsxxhaps.supabase.co/storage/v1/object/public/userIcon/tanuki.PNG1351?t=2023-06-05T07%3A40%3A07.886Z",
@@ -32,6 +33,23 @@ export default function IslandDetail() {
       .select("*")
       .eq("id", islandId.id) // 島のIDに応じてフィルタリングする（islandId.idは該当する島のID）
       .eq("status", false);
+
+    const { data: user, error: userError } = await supabase
+      .from("users")
+      .select("id")
+      .eq("id", data[0].ownerID);
+
+    const owner = user[0].id.toString();
+
+    // ownerじゃない人には「編集・削除」ボタン機能を表示させない
+    if (owner !== userId) {
+      console.log("ownerじゃありません");
+      setButton(false);
+    }
+    if (userError) {
+      console.error("owner情報の取得に失敗しました:", error);
+    }
+
     if (error) {
       console.error("島の詳細情報の取得に失敗しました:", error);
       return;
@@ -156,11 +174,13 @@ export default function IslandDetail() {
               <CreateSendingMessage closeModal={closeModal} table="island" />
             )}
           </div>
-          <div className={styles.editbox}>
-            <button id={styles.edit_btn} onClick={Handler}>
-              編集・削除
-            </button>
-          </div>
+          {button && (
+            <div className={styles.editbox}>
+              <button id={styles.edit_btn} onClick={Handler}>
+                編集・削除
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/island/[id].tsx
+++ b/src/island/[id].tsx
@@ -43,7 +43,6 @@ export default function IslandDetail() {
 
     // ownerじゃない人には「編集・削除」ボタン機能を表示させない
     if (owner !== userId) {
-      console.log("ownerじゃありません");
       setButton(false);
     }
     if (userError) {


### PR DESCRIPTION
## 変更箇所のURL

- src/event/create/tsx
- src/island/[id].tsx

## やったこと

- イベント作成時にownerIDを挿入するよう変更
※supabaseの方でownerIDをnullableになっていたのを不可に変更

- サークル詳細画面にて、owner以外には「編集・削除」ボタンが表示されないように変更

## やらないこと

CSS

## できるようになること（ユーザ目線）

ownerのみサークル編集

## できなくなること（ユーザ目線）

無
## 動作確認

画面上・supabaseにownerIDが入るかどうか

## その他

イベント編集画面の「編集・削除」ボタンの表示・非表示はイベント編集画面機能実装が終了してから行います。