### PR TITLE
島民一覧修正

### DIFF
--- a/src/components/MembersList.tsx
+++ b/src/components/MembersList.tsx
@@ -31,8 +31,6 @@ export default function MembersList({
   const tmpLoginID = GetCookieID();
   const loginID = Number(tmpLoginID);
 
-  console.log(displayData);
-
   // DBからデータを取得
   useEffect(() => {
     if (!loginUser) {
@@ -72,7 +70,14 @@ export default function MembersList({
           ) as Entryusers[];
           //各島民と難民を一つの配列にしまう
           const conbined = tmpArry.concat(userData);
-          setEntryUsers(conbined);
+          const updatedData = conbined.map((item) => {
+            if (item.userID === displayData.ownerID) {
+              item.users.firstName += "(オーナー)";
+            }
+            return item;
+          });
+          setEntryUsers(updatedData);
+          console.log(updatedData);
           getLoginUser();
         }
       }
@@ -90,7 +95,15 @@ export default function MembersList({
         const userData = entryData.filter(
           (user) => user.userID,
         ) as Entryusers[];
-        setEntryUsers(userData);
+
+        const updatedData = userData.map((item) => {
+          if (item.userID === displayData.ownerID) {
+            item.users.firstName += "(オーナー)";
+          }
+          return item;
+        });
+
+        setEntryUsers(updatedData);
         getLoginUser();
       }
     }
@@ -149,7 +162,7 @@ export default function MembersList({
               />
               <div className={styles.name}>
                 {loginUser.familyName}
-                {loginUser.firstName}&nbsp;({loginUser.department}) (オーナー)
+                {loginUser.firstName}&nbsp;({loginUser.department})(オーナー)
               </div>
             </td>
           </tr>

--- a/src/components/MembersList.tsx
+++ b/src/components/MembersList.tsx
@@ -77,7 +77,6 @@ export default function MembersList({
             return item;
           });
           setEntryUsers(updatedData);
-          console.log(updatedData);
           getLoginUser();
         }
       }

--- a/src/components/MembersList.tsx
+++ b/src/components/MembersList.tsx
@@ -31,10 +31,14 @@ export default function MembersList({
   const tmpLoginID = GetCookieID();
   const loginID = Number(tmpLoginID);
 
+  console.log(displayData);
+
   // DBからデータを取得
   useEffect(() => {
-    fetchData();
-  }, [entryUsers]);
+    if (!loginUser) {
+      fetchData();
+    }
+  }, [entryUsers, newEntryUsers]);
 
   async function fetchData() {
     //イベントの場合
@@ -69,6 +73,7 @@ export default function MembersList({
           //各島民と難民を一つの配列にしまう
           const conbined = tmpArry.concat(userData);
           setEntryUsers(conbined);
+          getLoginUser();
         }
       }
     } else {
@@ -81,11 +86,18 @@ export default function MembersList({
         .eq(`status`, false);
       if (entryError || !entryData) {
         console.log(entryError, "entryError");
+      } else {
+        const userData = entryData.filter(
+          (user) => user.userID,
+        ) as Entryusers[];
+        setEntryUsers(userData);
+        getLoginUser();
       }
-      const userData = entryData.filter((user) => user.userID) as Entryusers[];
-      setEntryUsers(userData);
     }
+  }
 
+  //ログインユーザーのデータを取得
+  const getLoginUser = async () => {
     //ログインしているユーザーのデータを取得
     const { data: login, error: loginError } = await supabase
       .from("users")
@@ -105,7 +117,7 @@ export default function MembersList({
       );
       setNewEntryUsers(filteredUsers.length > 0 ? filteredUsers : []);
     }
-  }
+  };
 
   // 自分以外のユーザーの一覧表示
   const anotherUser = (user: Entryusers) => {

--- a/src/components/entryPermit.tsx
+++ b/src/components/entryPermit.tsx
@@ -3,8 +3,6 @@ import { supabase } from "../createClient";
 import styles from "../styles/entryPermit.module.css";
 import { useNavigate, useParams } from "react-router-dom";
 import { Message } from "../types/entryPermit";
-import SendMessages from "./SendMessages";
-import { arrayBuffer } from "stream/consumers";
 
 export default function EntryPermit({ table }: { table: string }) {
   const [message, setMessage] = useState<Message>();
@@ -37,7 +35,11 @@ export default function EntryPermit({ table }: { table: string }) {
       .eq("status", false);
     if (error) {
       console.log(error, "エラー");
+    }
+    if (!data || data.length === 0) {
+      console.log("ポストまたはメッセージがみつかりませんでした");
     } else {
+      console.log(data);
       //applicationsが取得できたものだけで新たな配列を作成
       const selectApp = data[0].messages.filter(
         (message) => message.applications.length > 0 && !message.isAnswered,

--- a/src/components/entryPermit.tsx
+++ b/src/components/entryPermit.tsx
@@ -39,7 +39,6 @@ export default function EntryPermit({ table }: { table: string }) {
     if (!data || data.length === 0) {
       console.log("ポストまたはメッセージがみつかりませんでした");
     } else {
-      console.log(data);
       //applicationsが取得できたものだけで新たな配列を作成
       const selectApp = data[0].messages.filter(
         (message) => message.applications.length > 0 && !message.isAnswered,

--- a/src/components/modalWindows/deleteConfirmation.tsx
+++ b/src/components/modalWindows/deleteConfirmation.tsx
@@ -35,7 +35,11 @@ export default function DeleteComfirmation({
           window.location.reload();
         }
       };
-      return <button onClick={handler}>はい</button>;
+      return (
+        <button onClick={handler} className={styles.btn}>
+          はい
+        </button>
+      );
       // return <LeaveButton table={table} params={params} user={user} />;
     } else if (category === "追放") {
       const handler = async () => {
@@ -52,7 +56,11 @@ export default function DeleteComfirmation({
           window.location.reload();
         }
       };
-      return <button onClick={handler}>はい</button>;
+      return (
+        <button onClick={handler} className={styles.btn}>
+          はい
+        </button>
+      );
     } else if (category === "譲渡") {
       //オーナー権限を譲渡する
       const handler = async () => {
@@ -60,6 +68,7 @@ export default function DeleteComfirmation({
           .from(`${table}s`)
           .update({ ownerID: user })
           .eq("id", params);
+
         if (error) {
           console.error(error.message);
         } else {
@@ -68,7 +77,11 @@ export default function DeleteComfirmation({
         }
       };
 
-      return <button onClick={handler}>はい</button>;
+      return (
+        <button onClick={handler} className={styles.btn}>
+          はい
+        </button>
+      );
     }
   };
 
@@ -85,11 +98,10 @@ export default function DeleteComfirmation({
             />
             <div className={styles.main}>
               <div className={styles.title}>
-                <h3 className={styles.h3}>{islandName}島</h3>
                 <p className={styles.messageName}>{text}</p>
               </div>
             </div>
-            <div className={styles.btn}>{addHandler(category)}</div>
+            <div>{addHandler(category)}</div>
           </div>
         </div>
       </div>

--- a/src/event/post.tsx
+++ b/src/event/post.tsx
@@ -98,7 +98,7 @@ export default function EventPost() {
         <MenubarEvent />
         <div className={styles.islandPostBack}>
           <h1>POST</h1>
-          <Link to={`/island/post/entryPermit/${paramsID}`}>
+          <Link to={`/event/post/entryPermit/${paramsID}`}>
             <button className={styles.btn2}>イベント参加許可待ち申請</button>
           </Link>
           <button onClick={openModal} className={styles.btn1}>

--- a/src/event/post/entryPermitPage.tsx
+++ b/src/event/post/entryPermitPage.tsx
@@ -1,4 +1,4 @@
-import MenubarIsland from "../../components/menubarIsland";
+import MenubarEvent from "../../components/menubarEvent";
 import EntryPermit from "../../components/entryPermit";
 import styles from "../../styles/entryPermit.module.css";
 import LogSt from "../../components/cookie/logSt";
@@ -7,7 +7,7 @@ export default function EventEntryPermitPage() {
   LogSt();
   return (
     <div className={styles.display}>
-      <MenubarIsland />
+      <MenubarEvent />
       <EntryPermit table={"event"} />
     </div>
   );

--- a/src/styles/createSendingMessage.module.css
+++ b/src/styles/createSendingMessage.module.css
@@ -25,7 +25,7 @@
   position: relative;
 }
 .messageName {
-  margin-top: 0;
+  margin-top: 16vh;
 }
 
 .close {

--- a/src/styles/membersList.module.css
+++ b/src/styles/membersList.module.css
@@ -31,7 +31,7 @@
   display: flex;
 }
 .td2 {
-  width: 80%;
+  width: 60%;
   height: 15%;
   padding-right: 8vh;
   background-color: rgba(255, 254, 245, 1);


### PR DESCRIPTION
## 変更箇所のURL

島・イベントの島民一覧

## やったこと

ログインユーザーがオーナーでないとき、
島民一覧でオーナーの人の名前の後ろに(オーナー)と表示させる

島民一覧から表示できるモーダルを修正

## やらないこと



## できるようになること（ユーザ目線）



## できなくなること（ユーザ目線）


## 動作確認


## その他

