### PR TITLE
参加サークルの修正

### DIFF
--- a/src/event/edit.tsx
+++ b/src/event/edit.tsx
@@ -315,7 +315,6 @@ export default function EventEdit() {
           if (islandEventError) {
             console.error("共同開催島情報追加失敗");
           }
-          navigate(`/`);
           window.location.reload();
         })
       );


### PR DESCRIPTION
## 変更箇所のURL

* イベント編集・削除（初期表示）
<img width="1440" alt="スクリーンショット 2023-06-14 16 29 57" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/a775f497-2336-49ba-bef3-2e602ea28e94">

* 編集ボタンを押下→イベント削除の×ボタンを表示
<img width="1440" alt="スクリーンショット 2023-06-14 16 30 07" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/96095325-fea1-4f5a-a813-c138e2386e4c">

* ×ボタンを押下→参加サークルを選択
<img width="1440" alt="スクリーンショット 2023-06-14 16 30 34" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/898e217a-1caa-4c12-b2bd-f4350277c9a0">

* 保存ボタンを押下→トップ画面に遷移
<img width="1440" alt="スクリーンショット 2023-06-14 16 30 45" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/69df3884-b297-4f10-8bb7-a1a78c9baddf">

* ×を押したサークルのstatus→tureに変更、新たに追加したサークルがuserEntryStatusに格納
<img width="1440" alt="スクリーンショット 2023-06-14 16 31 27" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/fa263236-d1a0-41db-ae04-aeb8c90cda84">



## やったこと

* 既に参加しているサークルを削除できるよう実装

## やらないこと

* css

## できるようになること（ユーザ目線）

* 参加サークルの変更、削除が可能

## できなくなること（ユーザ目線）

* なし
