### PR TITLE
Feature/tagAddEdit

### DIFF
--- a/src/components/createIsland/addtag.tsx
+++ b/src/components/createIsland/addtag.tsx
@@ -43,10 +43,17 @@ export default function AddTag({
     if (inputValue == "") {
       setTagNameError("タグ名を入力してください");
     }
-    if (inputValueK == "") {
+    if (inputValueK === "") {
       setTagNameKanaError("タグ名かなを入力してください");
     }
-    if (inputValue !== "" && inputValueK !== "") {
+    if (/^[ァ-ヶーa-zA-Z0-9]+$/.test(inputValueK)) {
+      setTagNameKanaError("ひらがなで入力してください");
+    }
+    if (
+      inputValue !== "" &&
+      inputValueK !== "" &&
+      !/^[ァ-ヶーa-zA-Z0-9]+$/.test(inputValueK)
+    ) {
       setSelectedValue((value) => [...value, inputValue]);
       // タグデータ作成
       const newTag = { Name: inputValue, NameKana: inputValueK };
@@ -84,7 +91,7 @@ export default function AddTag({
             <span className={styles.spanTg}>{tagNameError}</span>
           </div>
         )}
-        <label htmlFor="tagNameKana">ふりがな：</label>
+        <label htmlFor="tagNameKana">タグ名かな：</label>
         <input
           type="text"
           value={inputValueK}


### PR DESCRIPTION
## 変更箇所のURL

- src/components/createIsland/addTag.tsx

## やったこと

タグ追加項目で、タグかな項目で英数字入力、カナ入力された状態で「追加」ボタンを押されたときにエラー表示を追加
- 英数字入力時
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/b486c46e-7d3c-43ec-afa6-bcc135a903de)

- カタカナ入力時
![image](https://github.com/Hayaka3a/company-circle-sns/assets/116147591/107caee0-217a-4d8d-b61a-5333fe0fdc71)


## やらないこと

無

## できるようになること（ユーザ目線）

タグの利用向上

## できなくなること（ユーザ目線）

無

## 動作確認

画面上

## その他

無