### PR TITLE
住民申請関連修正

### DIFF
--- a/src/components/MembersList.tsx
+++ b/src/components/MembersList.tsx
@@ -257,7 +257,6 @@ export default function MembersList({
               return (
                 <tr key={user.id} className={styles.tr}>
                   {anotherUser(user)}
-                  <td className={styles.td}></td>
                 </tr>
               );
             })}

--- a/src/components/entryPermit.tsx
+++ b/src/components/entryPermit.tsx
@@ -149,6 +149,7 @@ export default function EntryPermit({ table }: { table: string }) {
       .update({
         isRead: true,
         isAnswered: true,
+        status: false,
       })
       .eq(`id`, messageID);
     if (updateError) {

--- a/src/island/[id].tsx
+++ b/src/island/[id].tsx
@@ -83,7 +83,8 @@ export default function IslandDetail() {
     const { data: message, error: messageError } = await supabase
       .from("messages")
       .select("*")
-      .eq("postedBy", data[0].id);
+      .eq("postedBy", data[0].id)
+      .eq("status", false);
 
     const appMsg = message.filter((msg) => msg.message === "参加申請");
 
@@ -92,7 +93,8 @@ export default function IslandDetail() {
       const { data: island, error: islandError } = await supabase
         .from("posts")
         .select("*")
-        .eq("islandID", Number(islandId.id));
+        .eq("islandID", Number(islandId.id))
+        .eq("status", false);
 
       if (islandError) {
         console.log("島ポスト番号取得失敗");

--- a/src/styles/entryPermit.module.css
+++ b/src/styles/entryPermit.module.css
@@ -68,6 +68,7 @@
   box-shadow: 0.7vh 0.7vh rgba(255, 182, 112, 1);
   transition: 0.3s ease-in-out;
   height: 6vh;
+  background-color: white;
 }
 .OK:hover {
   box-shadow: none;
@@ -85,6 +86,7 @@
   box-shadow: 0.7vh 0.7vh #27acd9;
   transition: 0.3s ease-in-out;
   height: 6vh;
+  background-color: white;
 }
 .NG:hover {
   box-shadow: none;


### PR DESCRIPTION
## 変更箇所のURL

島詳細
イベント詳細
住民申請許可画面
島民一覧

## やったこと

・島民一覧で謎の空白行があったので削除
・詳細画面で住民申請をしているか確認する部分で、messagesのstatusがfalseの参加申請だけ取得するように変更
・参加申請を許可・拒否した場合、applicationsのstatusのみ変更していたのをmessagesのstatusもfalseにするように変更

## やらないこと


## できるようになること（ユーザ目線）



## できなくなること（ユーザ目線）



## 動作確認



## その他

