### PR TITLE
サークル削除の修正

### DIFF
--- a/src/island/edit.tsx
+++ b/src/island/edit.tsx
@@ -101,17 +101,22 @@ export default function IslandEdit() {
         const { error: islandsTagError } = await supabase
           .from("tagStatus")
           .update({ status: "true" })
-          .eq("id", islandID);
+          .eq("islandID", islandID);
+
+        const { error: islandStatusError } = await supabase
+          .from("userEntryStatus")
+          .update({ status: "true" })
+          .eq("islandID", islandID);
 
         const { error: postsError } = await supabase
           .from("posts")
           .update({ status: "true" })
-          .eq("id", islandID);
+          .eq("islandID", islandID);
 
-        if (islandsError || islandsTagError || postsError) {
+        if (islandsError || islandsTagError || islandStatusError || postsError) {
           console.error(
             "Error changing status :",
-            islandsError || islandsTagError || postsError,
+            islandsError || islandsTagError || islandStatusError || postsError,
           );
           // Cookie情報の削除
           if (document.cookie !== "") {


### PR DESCRIPTION
## 変更箇所のURL

* 削除したい該当のサークル名入力
<img width="1440" alt="スクリーンショット 2023-06-21 14 22 19" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/e5bd78e2-1010-4d22-96d4-0e2d210e0daa">

* 削除完了
<img width="1440" alt="スクリーンショット 2023-06-21 14 22 33" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/9e651cda-3e7a-41cc-806f-f065069a1a19">

* 削除完了後、サークル新規作成画面に遷移・ハンバーガーメニューの参加島に削除したサークルが表示されない
<img width="1440" alt="スクリーンショット 2023-06-21 14 22 50" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/e4aff6b2-b81b-4119-9d70-0c4dc965ec4f">

* islandsテーブルの該当のstatus→trueに変更
<img width="1440" alt="スクリーンショット 2023-06-21 14 23 28" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/03eca7f3-e57e-4de7-ab15-6d9f09233a4c">

* postsテーブルの該当のstatus→trueに変更
<img width="1440" alt="スクリーンショット 2023-06-21 14 23 39" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/69ab541d-2bdb-4c6e-93a9-95d9d2c69e9b">

* tagStatusテーブルの該当のstatus→trueに変更
<img width="1440" alt="スクリーンショット 2023-06-21 14 23 47" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/ffc3f35e-bfe6-4df2-a78b-dd951fb75655">

* userEntryStatusテーブルの該当のstatus→trueに変更
<img width="1440" alt="スクリーンショット 2023-06-21 14 24 06" src="https://github.com/Hayaka3a/company-circle-sns/assets/116234995/2c429a22-97a2-4fdd-9809-3afa51cb253c">

## やったこと

* 削除をした際に、islands、posts、tagStatus、userEntryStatusテーブルのstatusをtrueに変更（論理削除）

## やらないこと

* css

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
