### PR TITLE
コンボボックス「追加」ボタン削除によるエラー解消

### DIFF
--- a/src/components/comboBox/comboBoxUser/handleInputChange.tsx
+++ b/src/components/comboBox/comboBoxUser/handleInputChange.tsx
@@ -32,13 +32,6 @@ export default function HandleInputChange({
     }
   };
 
-  // 追加ボタンだけでなく、enterキーでもaddHandlerを発動させる
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter") {
-      addHandler();
-    }
-  };
-
   return (
     <div>
       <input
@@ -46,7 +39,6 @@ export default function HandleInputChange({
         maxLength={24}
         value={inputValue}
         onChange={handleInputChange}
-        onKeyDown={handleKeyDown}
         id={htmlFor}
         className={styles.comboBoxUser}
       />


### PR DESCRIPTION

## やったこと

- スカウト画面でユーザー名を入力した状態で「enter」ボタンを押下したときに発生したエラーを解消
原因：enterキーでも選択されるよう設定していたため。