### PR TITLE
イベント関係エラー修正

### DIFF
--- a/src/components/hooks/SubFetchIsEve.ts
+++ b/src/components/hooks/SubFetchIsEve.ts
@@ -30,8 +30,10 @@ export default function SubFetchIsEve({
       //島が参加しているイベント取得
       const joinIsArray = tmpIs
         .flatMap((data) => data.islands)
-        .filter((island) => island !== null)
+        .filter((island) => island !== null || undefined)
         .map((island) => island.id);
+
+      console.log(joinIsArray);
 
       let { data: eveData, error: eveError } = await supabase
         .from("userEntryStatus")
@@ -45,14 +47,15 @@ export default function SubFetchIsEve({
         //取得した２つのデータを１つの配列にする
         const tmpEve = eveData
           .flatMap((data) => data.events)
-          .filter((event) => event !== null)
+          .filter((event) => event !== null || undefined)
           .map((data) => ({
-            events: data.events,
+            events: data,
             islands: null,
           })) as {
           events: Event | null;
           islands: null;
         }[];
+
         tmpEve.map((data) => tmpIs.push(data));
 
         setCombi(tmpIs);

--- a/src/components/menberList/fetchMembers.ts
+++ b/src/components/menberList/fetchMembers.ts
@@ -37,15 +37,28 @@ export async function fetchMembers({
       if (entryError || !entryData) {
         console.log(entryError, "entryError");
       } else {
+        //userIDが存在するデータのみに絞り込み、各島民と難民を一つの配列にしまう
         const userData = entryData.filter(
           (user) => user.userID,
         ) as Entryusers[];
-        //各島民と難民を一つの配列にしまう
-        const conbined = tmpArry.concat(userData);
-        const updatedData = conbined.map((item) => {
+        const combined = tmpArry.concat(userData);
+
+        // 同じuserIDを持つデータを除外するための処理
+        const uniqueCombined = [];
+        const seenUserIDs = new Set(); // 既に追加されたuserIDを保持するSet
+
+        for (const item of combined) {
+          if (!seenUserIDs.has(item.userID)) {
+            uniqueCombined.push(item);
+            seenUserIDs.add(item.userID);
+          }
+        }
+
+        const updatedData = uniqueCombined.map((item) => {
           if (item.userID === displayData.ownerID) {
             item.users.firstName += "(オーナー)";
           }
+
           return item;
         });
         setEntryUsers(updatedData);

--- a/src/components/modalWindows/sendingScout/createSendingScout.tsx
+++ b/src/components/modalWindows/sendingScout/createSendingScout.tsx
@@ -38,25 +38,18 @@ export default function CreateSendingScout({
   const getPost = async () => {
     const { data: posts, error: postError } = await supabase
       .from("posts")
-      .select(`id,islands(islandName)`)
+      .select(`id`)
       .eq(`${table}ID`, paramsID)
       .eq("status", false);
 
     if (postError) {
-      console.log(postError, "エラー");
+      console.log(postError, "postsエラー");
     }
-
     if (!posts || posts.length === 0) {
-      console.log("postが見つかりません");
+      console.log("postByに格納するpostIDが見つかりません", posts);
     } else {
       const post = posts[0];
       setPostBy(post.id);
-      if (post.islands && post.islands.length > 0) {
-        const islandN = post.islands[0] as { islandName: string };
-        setIslandName(islandN.islandName);
-      } else {
-        console.log("islandNameが見つかりません");
-      }
     }
   };
 
@@ -68,7 +61,7 @@ export default function CreateSendingScout({
       .eq(`${table}ID`, paramsID)
       .eq("status", false);
     if (entryError) {
-      console.log(entryError, "エラー");
+      console.log(entryError, "entryエラー");
     }
     if (!entryUser) {
       console.log("ユーザーが見つかりません");
@@ -81,7 +74,7 @@ export default function CreateSendingScout({
         .select(`id,familyName,firstName,familyNameKana,firstNameKana`)
         .eq("status", false);
       if (usersError) {
-        console.log(usersError, "エラー");
+        console.log(usersError, "usersエラー");
       }
       if (!users) {
         console.log("全ユーザーが見つかりません");
@@ -126,7 +119,7 @@ export default function CreateSendingScout({
             .eq("userID", islandMembers[0].id)
             .eq("status", false);
           if (postError) {
-            console.log(postError, "エラー");
+            console.log(postError, "post2エラー");
           }
           setPost(posts[0].id);
         }

--- a/src/event/post.tsx
+++ b/src/event/post.tsx
@@ -105,7 +105,7 @@ export default function EventPost() {
             イベントに招待する
           </button>
           {modal && (
-            <CreateSendingScout closeModal={closeModal} table="island" />
+            <CreateSendingScout closeModal={closeModal} table="event" />
           )}
           <div className={styles.postMessageBack}>
             <h2>受信メッセージ✉️</h2>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -105,7 +105,7 @@ export default function Index() {
                     {events.slice(0, 5).map((event) => (
                       <div key={event.id} className={styles.event}>
                         <Link
-                          to={`/island/${event.id}`}
+                          to={`/event/${event.id}`}
                           className={styles.link}
                           data-testid="eventLink"
                         >

--- a/src/message.tsx
+++ b/src/message.tsx
@@ -50,8 +50,7 @@ export default function Message() {
     }
   }, [imageUrl]);
 
-
-  const fetchPosts = async (messagesPosteBy) => {    
+  const fetchPosts = async (messagesPosteBy) => {
     const { data: posts, error: postsError } = await supabase
       .from("posts")
       .select("id, userID, islandID, eventID")
@@ -183,7 +182,7 @@ export default function Message() {
       },
     ]);
 
-    console.log(posts[0].id)
+    console.log(posts[0].id);
 
     if (messageError) {
       console.error("メッセージの送信中にエラーが発生しました:", error);
@@ -319,6 +318,7 @@ export default function Message() {
                 className={styles.textArea}
                 id="message-text"
                 placeholder="返信メッセージを入力してください"
+                maxLength={200}
               />
             </div>
           )}


### PR DESCRIPTION
## 変更箇所のURL

トップページ
イベントページ

## やったこと

* イベントからのスカウト送信機能修正
* イベント参加者一覧にて、複数島に参加している場合二重に表示されていたのを修正
* ハンバーガーメニューにて、参加イベント表示部分修正
* indexにて、新着イベントリンクを踏んだ際の遷移先が/islandになっていたのを修正
* index内のlogst修正

## やらないこと



## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）



## 動作確認

## その他
