### PR TITLE
編集画面での島名重複チェック機能追加

### DIFF
--- a/src/island/edit.tsx
+++ b/src/island/edit.tsx
@@ -12,6 +12,8 @@ import ComboBoxTag from "../components/comboBox/comboBoxTag/comboBoxTag";
 import FetchUsers from "../components/fetchUsers";
 import IslandDone from "../components/islandDone";
 import FetchIslandEdit from "../components/fetchIslandEdit";
+import IslandName from "../components/createIsland/islandName/islandName";
+import Detail from "../components/createIsland/detail/detail";
 
 export default function IslandEdit() {
   LogSt();
@@ -310,26 +312,18 @@ export default function IslandEdit() {
             <tr className={styles.tr}>
               <th className={styles.th}>島名</th>
               <td className={styles.td}>
-                <input
-                  type="text"
-                  id="islandName"
-                  className={styles.input}
-                  value={islandName}
-                  onChange={handleIslandNameChange}
-                  maxLength={100}
+                <IslandName
+                  islandName={islandName}
+                  setName={setIslandName}
+                  nameAlreadyError={nameAlreadyError}
+                  setNameAlreadyError={setNameAlreadyError}
                 />
               </td>
             </tr>
             <tr className={styles.tr}>
               <th className={styles.th}>活動内容</th>
               <td className={styles.td}>
-                <textarea
-                  id="detail"
-                  className={styles.detail}
-                  value={detail}
-                  maxLength={300}
-                  onChange={(event) => handleDetailChange(event.target.value)} // 修正: テキストエリアの値が変更されたら handleDetailChange 関数を呼び出す
-                />
+                <Detail detail={detail} setDetail={setDetail} />
               </td>
             </tr>
             <tr className={styles.tr}>


### PR DESCRIPTION
## 変更箇所のURL



## やったこと

* 編集画面にてすでに登録のある島名を入力した場合にエラー表示をさせる

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
